### PR TITLE
ci: build from outside the container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,19 +11,17 @@ jobs:
       matrix:
         ncs_version: [2.4]
         board: [zswatch_nrf5340_cpuapp@1,zswatch_nrf5340_cpuapp@2]
-    container: 
-      image: nordicplayground/nrfconnect-sdk:v${{ matrix.ncs_version }}-branch
-      options: --user root
-    steps:    
-      - name: Install deps
-        run: |
-          apt-get --no-install-recommends -y install git
+    steps:
       - name: Clone repository
         uses: actions/checkout@v2
         with:
+          path: project
           submodules: recursive
       - name: Build ZSWatch Binaries
-        run: west build --board ${{ matrix.board }} app
+        working-directory: project
+        run: |
+          docker run -v $PWD:/workdir/project nordicplayground/nrfconnect-sdk:v${{ matrix.ncs_version }}-branch \
+            west build --board zswatch_nrf5340_cpuapp@2 /workdir/project/app
 
   Posix:
     name: Posix build


### PR DESCRIPTION
This fixes the build by not running the action inside the container but using the Docker image in the action.