### PR TITLE
Display power save optimizations

### DIFF
--- a/app/drivers/display/gc9a01.c
+++ b/app/drivers/display/gc9a01.c
@@ -374,10 +374,13 @@ static int gc9a01_pm_action(const struct device *dev,
 
     switch (action) {
         case PM_DEVICE_ACTION_RESUME:
+            err = gc9a01_write_cmd(dev, GC9A01A_SLPOUT, NULL, 0);
+            k_msleep(5); // According to datasheet wait 5ms after SLPOUT before next command.
             err = gc9a01_write_cmd(dev, GC9A01A_DISPON, NULL, 0);
             break;
         case PM_DEVICE_ACTION_SUSPEND:
             err = gc9a01_write_cmd(dev, GC9A01A_DISPOFF, NULL, 0);
+            err = gc9a01_write_cmd(dev, GC9A01A_SLPIN, NULL, 0);
             break;
         case PM_DEVICE_ACTION_TURN_ON:
             err = gc9a01_init(dev);

--- a/app/src/applications/accelerometer/accel_ui.c
+++ b/app/src/applications/accelerometer/accel_ui.c
@@ -86,9 +86,6 @@ void accel_ui_remove(void)
 
 void accel_ui_set_values(int32_t x, int32_t y, int32_t z)
 {
-    char buf[10];
-    memset(buf, 0, sizeof(buf));
-
     if (!root_page) {
         return;
     }
@@ -96,12 +93,9 @@ void accel_ui_set_values(int32_t x, int32_t y, int32_t z)
     lv_bar_set_value(bar_acc_y, y, LV_ANIM_ON);
     lv_bar_set_value(bar_acc_z, z, LV_ANIM_ON);
 
-    snprintf(buf, sizeof(buf), "X: %d", x);
-    lv_label_set_text(acc_x_label, buf);
-    snprintf(buf, sizeof(buf), "Y: %d", y);
-    lv_label_set_text(acc_y_label, buf);
-    snprintf(buf, sizeof(buf), "Z: %d", z);
-    lv_label_set_text(acc_z_label, buf);
+    lv_label_set_text_fmt(acc_x_label, "X: %d", x);
+    lv_label_set_text_fmt(acc_y_label, "Y: %d", y);
+    lv_label_set_text_fmt(acc_z_label, "Z: %d", z);
 }
 
 static void close_button_pressed(lv_event_t *e)

--- a/app/src/applications/application_manager.c
+++ b/app/src/applications/application_manager.c
@@ -3,7 +3,7 @@
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
 
-LOG_MODULE_REGISTER(APP_MANAGER, LOG_LEVEL_DBG);
+LOG_MODULE_REGISTER(APP_MANAGER, LOG_LEVEL_INF);
 
 #define MAX_APPS        15
 #define INVALID_APP_ID  0xFF
@@ -224,8 +224,6 @@ static void draw_application_picker(void)
             lv_obj_add_event_cb(entry, app_clicked, LV_EVENT_CLICKED, (void *)i);
         }
     }
-
-    LOG_ERR("%d, %d, %d", num_apps, num_visible_apps, 0);
 
     LV_IMG_DECLARE(close_icon);
     entry = create_application_list_entry(grid, &close_icon, "Close", num_visible_apps);

--- a/app/src/applications/compass/compass_ui.c
+++ b/app/src/applications/compass/compass_ui.c
@@ -59,8 +59,6 @@ void compass_ui_remove(void)
 
 void compass_ui_set_heading(double heading)
 {
-    char buf[100] = {};
-    snprintf(buf, sizeof(buf), "%.0f°", heading);
-    lv_label_set_text(compass_label, buf);
+    lv_label_set_text_fmt(compass_label, "%.0f°", heading);
     lv_img_set_angle(compass_img, heading * 10);
 }

--- a/app/src/applications/info/info_app.c
+++ b/app/src/applications/info/info_app.c
@@ -19,6 +19,7 @@ static void info_app_stop(void);
 
 // Functions related to app functionality
 static void timer_callback(lv_timer_t *timer);
+static void on_reset_pressed(void);
 
 LV_IMG_DECLARE(statistic_icon);
 
@@ -37,7 +38,7 @@ static void info_app_start(lv_obj_t *root, lv_group_t *group)
     char addr[BT_ADDR_LE_STR_LEN];
     size_t addr_count = 1;
 
-    info_ui_show(root);
+    info_ui_show(root, on_reset_pressed);
     info_ui_set_uptime_sec(k_uptime_get() / 1000);
     info_ui_set_total_uptime_sec(retained.uptime_sum / 1000);
     info_ui_set_wakeup_time_sec(retained.wakeup_time / 1000, (retained.wakeup_time / (double)retained.uptime_sum) * 100);
@@ -67,6 +68,11 @@ static void timer_callback(lv_timer_t *timer)
     info_ui_set_ref_off_time_sec(retained.display_off_time / 1000,
                                  (retained.display_off_time / (double)retained.uptime_sum) * 100);
     info_ui_set_time_to_inactive_sec(zsw_power_manager_get_ms_to_inactive() / 1000);
+}
+
+static void on_reset_pressed(void)
+{
+    retained_reset();
 }
 
 static int info_app_add(void)

--- a/app/src/applications/info/info_app.c
+++ b/app/src/applications/info/info_app.c
@@ -41,6 +41,8 @@ static void info_app_start(lv_obj_t *root, lv_group_t *group)
     info_ui_set_uptime_sec(k_uptime_get() / 1000);
     info_ui_set_total_uptime_sec(retained.uptime_sum / 1000);
     info_ui_set_wakeup_time_sec(retained.wakeup_time / 1000, (retained.wakeup_time / (double)retained.uptime_sum) * 100);
+    info_ui_set_ref_off_time_sec(retained.display_off_time / 1000,
+                                 (retained.display_off_time / (double)retained.uptime_sum) * 100);
     info_ui_set_time_to_inactive_sec(zsw_power_manager_get_ms_to_inactive() / 1000);
     info_ui_set_resets(retained.boots);
 
@@ -62,6 +64,8 @@ static void timer_callback(lv_timer_t *timer)
     info_ui_set_uptime_sec(k_uptime_get() / 1000);
     info_ui_set_total_uptime_sec(retained.uptime_sum / 1000);
     info_ui_set_wakeup_time_sec(retained.wakeup_time / 1000, (retained.wakeup_time / (double)retained.uptime_sum) * 100);
+    info_ui_set_ref_off_time_sec(retained.display_off_time / 1000,
+                                 (retained.display_off_time / (double)retained.uptime_sum) * 100);
     info_ui_set_time_to_inactive_sec(zsw_power_manager_get_ms_to_inactive() / 1000);
 }
 

--- a/app/src/applications/info/info_ui.c
+++ b/app/src/applications/info/info_ui.c
@@ -86,6 +86,8 @@ void info_ui_show(lv_obj_t *root)
     // Make root container fill the screen
     lv_obj_set_size(root_page, LV_PCT(100), LV_PCT(100));
 
+    lv_obj_clear_flag(root_page, LV_OBJ_FLAG_SCROLLABLE);
+
     create_ui(root_page);
 }
 
@@ -97,48 +99,41 @@ void info_ui_remove(void)
 
 void info_ui_set_uptime_sec(uint32_t uptime_seconds)
 {
-    char buf[100] = {};
     int days;
     int hours;
     int minutes;
     int seconds;
 
     seconds_to_time_chunks(uptime_seconds, &days, &hours, &minutes, &seconds);
-    snprintf(buf, sizeof(buf), "Uptime: %02d:%02d:%02d:%02d", days, hours, minutes, seconds);
-    lv_label_set_text(uptime_label, buf);
+    lv_label_set_text_fmt(uptime_label, "Uptime: %02d:%02d:%02d:%02d", days, hours, minutes, seconds);
 }
 
 void info_ui_set_resets(uint32_t resets)
 {
-    char buf[100] = {};
-    snprintf(buf, sizeof(buf), "Resets:\t%d", resets);
-    lv_label_set_text(resets_label, buf);
+    lv_label_set_text_fmt(resets_label, "Resets:\t%d", resets);
 }
 
 void info_ui_set_total_uptime_sec(uint32_t uptime_seconds)
 {
-    char buf[100] = {};
     int days;
     int hours;
     int minutes;
     int seconds;
 
     seconds_to_time_chunks(uptime_seconds, &days, &hours, &minutes, &seconds);
-    snprintf(buf, sizeof(buf), "Total uptime: %02d:%02d:%02d:%02d", days, hours, minutes, seconds);
-    lv_label_set_text(runtime_label, buf);
+    lv_label_set_text_fmt(runtime_label, "Total uptime: %02d:%02d:%02d:%02d", days, hours, minutes, seconds);
 }
 
 void info_ui_set_wakeup_time_sec(uint64_t total_wake_time, uint32_t percent_used)
 {
-    char buf[100] = {};
     int days;
     int hours;
     int minutes;
     int seconds;
 
     seconds_to_time_chunks(total_wake_time, &days, &hours, &minutes, &seconds);
-    snprintf(buf, sizeof(buf), "Screen on: %02d:%02d:%02d:%02d (%d%%)", days, hours, minutes, seconds, percent_used);
-    lv_label_set_text(wake_time_label, buf);
+    lv_label_set_text_fmt(wake_time_label, "Screen on: %02d:%02d:%02d:%02d (%d%%)", days, hours, minutes, seconds,
+                          percent_used);
 }
 
 void info_ui_set_ref_off_time_sec(uint64_t total_off_time, uint32_t percent_off)
@@ -149,16 +144,13 @@ void info_ui_set_ref_off_time_sec(uint64_t total_off_time, uint32_t percent_off)
     int seconds;
 
     seconds_to_time_chunks(total_off_time, &days, &hours, &minutes, &seconds);
-    lv_label_set_text_fmt(disp_pwr_off_label, "3V3 off: %02d:%02d:%02d:%02d (%d%%)", days, hours, minutes, seconds,
+    lv_label_set_text_fmt(disp_pwr_off_label, "Stationary: %02d:%02d:%02d:%02d (%d%%)", days, hours, minutes, seconds,
                           percent_off);
 }
 
 void info_ui_set_time_to_inactive_sec(uint32_t time_left_seconds)
 {
-    char buf[100] = {};
-
-    snprintf(buf, sizeof(buf), "Time to inactive: %ds", time_left_seconds);
-    lv_label_set_text(inactive_time_label, buf);
+    lv_label_set_text_fmt(inactive_time_label, "Time to inactive: %ds", time_left_seconds);
 }
 
 void info_ui_set_mac_addr(char *mac_str)

--- a/app/src/applications/info/info_ui.c
+++ b/app/src/applications/info/info_ui.c
@@ -9,6 +9,7 @@ static lv_obj_t *uptime_label;
 static lv_obj_t *resets_label;
 static lv_obj_t *runtime_label;
 static lv_obj_t *wake_time_label;
+static lv_obj_t *disp_pwr_off_label;
 static lv_obj_t *mac_addr_label;
 static lv_obj_t *inactive_time_label;
 
@@ -52,18 +53,25 @@ static void create_ui(lv_obj_t *parent)
     lv_obj_set_y(wake_time_label, 15);
     lv_obj_set_align(wake_time_label, LV_ALIGN_LEFT_MID);
 
+    disp_pwr_off_label = lv_label_create(parent);
+    lv_obj_set_width(disp_pwr_off_label, LV_SIZE_CONTENT);
+    lv_obj_set_height(disp_pwr_off_label, LV_SIZE_CONTENT);
+    lv_obj_set_x(disp_pwr_off_label, 10);
+    lv_obj_set_y(disp_pwr_off_label, 35);
+    lv_obj_set_align(disp_pwr_off_label, LV_ALIGN_LEFT_MID);
+
     mac_addr_label = lv_label_create(parent);
     lv_obj_set_width(mac_addr_label, LV_SIZE_CONTENT);
     lv_obj_set_height(mac_addr_label, LV_SIZE_CONTENT);
-    lv_obj_set_x(mac_addr_label, 10);
-    lv_obj_set_y(mac_addr_label, 35);
+    lv_obj_set_x(mac_addr_label, 20);
+    lv_obj_set_y(mac_addr_label, 50);
     lv_obj_set_align(mac_addr_label, LV_ALIGN_LEFT_MID);
 
     inactive_time_label = lv_label_create(parent);
     lv_obj_set_width(inactive_time_label, LV_SIZE_CONTENT);
     lv_obj_set_height(inactive_time_label, LV_SIZE_CONTENT);
-    lv_obj_set_x(inactive_time_label, 20);
-    lv_obj_set_y(inactive_time_label, 50);
+    lv_obj_set_x(inactive_time_label, 30);
+    lv_obj_set_y(inactive_time_label, 65);
     lv_obj_set_align(inactive_time_label, LV_ALIGN_LEFT_MID);
 }
 
@@ -131,6 +139,18 @@ void info_ui_set_wakeup_time_sec(uint64_t total_wake_time, uint32_t percent_used
     seconds_to_time_chunks(total_wake_time, &days, &hours, &minutes, &seconds);
     snprintf(buf, sizeof(buf), "Screen on: %02d:%02d:%02d:%02d (%d%%)", days, hours, minutes, seconds, percent_used);
     lv_label_set_text(wake_time_label, buf);
+}
+
+void info_ui_set_ref_off_time_sec(uint64_t total_off_time, uint32_t percent_off)
+{
+    int days;
+    int hours;
+    int minutes;
+    int seconds;
+
+    seconds_to_time_chunks(total_off_time, &days, &hours, &minutes, &seconds);
+    lv_label_set_text_fmt(disp_pwr_off_label, "3V3 off: %02d:%02d:%02d:%02d (%d%%)", days, hours, minutes, seconds,
+                          percent_off);
 }
 
 void info_ui_set_time_to_inactive_sec(uint32_t time_left_seconds)

--- a/app/src/applications/info/info_ui.c
+++ b/app/src/applications/info/info_ui.c
@@ -4,6 +4,7 @@
 static void seconds_to_time_chunks(uint32_t time_seconds, int *days, int *hours, int *minutes, int *seconds);
 
 static lv_obj_t *root_page = NULL;
+static on_reset_ui_event_cb_t reset_callback;
 
 static lv_obj_t *uptime_label;
 static lv_obj_t *resets_label;
@@ -13,8 +14,16 @@ static lv_obj_t *disp_pwr_off_label;
 static lv_obj_t *mac_addr_label;
 static lv_obj_t *inactive_time_label;
 
+static void reset_btn_pressed(lv_event_t *e)
+{
+    if (reset_callback) {
+        reset_callback();
+    }
+}
+
 static void create_ui(lv_obj_t *parent)
 {
+    lv_obj_t *temp_obj;
     lv_obj_t *title_label = lv_label_create(parent);
     lv_obj_set_style_text_font(title_label, &lv_font_montserrat_18, 0);
     lv_label_set_text(title_label, "System info");
@@ -73,12 +82,27 @@ static void create_ui(lv_obj_t *parent)
     lv_obj_set_x(inactive_time_label, 30);
     lv_obj_set_y(inactive_time_label, 65);
     lv_obj_set_align(inactive_time_label, LV_ALIGN_LEFT_MID);
+
+    temp_obj = lv_btn_create(parent);
+    lv_obj_set_width(temp_obj, 100);
+    lv_obj_set_height(temp_obj, 30);
+    lv_obj_set_x(temp_obj, 0);
+    lv_obj_set_y(temp_obj, 0);
+    lv_obj_set_align(temp_obj, LV_ALIGN_BOTTOM_MID);
+    lv_obj_add_event_cb(temp_obj, reset_btn_pressed, LV_EVENT_CLICKED, NULL);
+
+    temp_obj = lv_label_create(temp_obj);
+    lv_obj_set_width(temp_obj, LV_SIZE_CONTENT);
+    lv_obj_set_height(temp_obj, LV_SIZE_CONTENT);
+    lv_obj_set_align(temp_obj, LV_ALIGN_CENTER);
+    lv_label_set_text(temp_obj, "Reset");
 }
 
-void info_ui_show(lv_obj_t *root)
+void info_ui_show(lv_obj_t *root, on_reset_ui_event_cb_t reset_cb)
 {
     assert(root_page == NULL);
 
+    reset_callback = reset_cb;
     // Create the root container
     root_page = lv_obj_create(root);
     // Remove the default border

--- a/app/src/applications/info/info_ui.h
+++ b/app/src/applications/info/info_ui.h
@@ -15,6 +15,8 @@ void info_ui_set_total_uptime_sec(uint32_t uptime_seconds);
 
 void info_ui_set_wakeup_time_sec(uint64_t total_wake_time, uint32_t percent_used);
 
+void info_ui_set_ref_off_time_sec(uint64_t total_off_time, uint32_t percent_off);
+
 void info_ui_set_time_to_inactive_sec(uint32_t time_left_seconds);
 
 void info_ui_set_mac_addr(char *mac_str);

--- a/app/src/applications/info/info_ui.h
+++ b/app/src/applications/info/info_ui.h
@@ -3,7 +3,9 @@
 #include <inttypes.h>
 #include <lvgl.h>
 
-void info_ui_show(lv_obj_t *root);
+typedef void(*on_reset_ui_event_cb_t)(void);
+
+void info_ui_show(lv_obj_t *root, on_reset_ui_event_cb_t reset_cb);
 
 void info_ui_remove(void);
 

--- a/app/src/applications/music_control/music_control_ui.c
+++ b/app/src/applications/music_control/music_control_ui.c
@@ -173,9 +173,7 @@ void music_control_ui_set_track_progress(int percent_played)
 
 void music_control_ui_set_time(int hour, int min, int second)
 {
-    char buf[30];
-    snprintf(buf, sizeof(buf), "%02d:%02d", hour, min);
-    lv_label_set_text(time_label, buf);
+    lv_label_set_text_fmt(time_label, "%02d:%02d", hour, min);
 }
 
 void music_control_ui_set_music_state(bool playing, int percent_played, bool shuffle)

--- a/app/src/applications/sensors_summary/sensors_summary_ui.c
+++ b/app/src/applications/sensors_summary/sensors_summary_ui.c
@@ -106,35 +106,25 @@ void sensors_summary_ui_remove(void)
 
 void sensors_summary_ui_set_pressure(double pressure)
 {
-    char buf[100] = {};
-    snprintf(buf, sizeof(buf), "Pressure:\t%.0f Pa", pressure);
-    lv_label_set_text(pressure_label, buf);
+    lv_label_set_text_fmt(pressure_label, "Pressure:\t%.0f Pa", pressure);
 }
 
 void sensors_summary_ui_set_humidity(double humidity)
 {
-    char buf[100] = {};
-    snprintf(buf, sizeof(buf), "Humidity:\t%.2f %%", humidity);
-    lv_label_set_text(humidity_label, buf);
+    lv_label_set_text_fmt(humidity_label, "Humidity:\t%.2f %%", humidity);
 }
 
 void sensors_summary_ui_set_temp(double temp)
 {
-    char buf[100] = {};
-    snprintf(buf, sizeof(buf), "Temp:\t%.2f C", temp);
-    lv_label_set_text(temp_label, buf);
+    lv_label_set_text_fmt(temp_label, "Temp:\t%.2f C", temp);
 }
 
 void sensors_summary_ui_set_rel_height(double rel_height)
 {
-    char buf[100] = {};
-    snprintf(buf, sizeof(buf), "Rel. height:\t%.2f m", rel_height);
-    lv_label_set_text(rel_height_label, buf);
+    lv_label_set_text_fmt(rel_height_label, "Rel. height:\t%.2f m", rel_height);
 }
 
 void sensors_summary_ui_set_gas(double gas)
 {
-    char buf[100] = {};
-    snprintf(buf, sizeof(buf), "Gas:\t%.2f", gas);
-    lv_label_set_text(gas_label, buf);
+    lv_label_set_text_fmt(gas_label, "Gas:\t%.2f", gas);
 }

--- a/app/src/ble_comm.c
+++ b/app/src/ble_comm.c
@@ -15,10 +15,8 @@
 
 LOG_MODULE_REGISTER(ble_comm, LOG_LEVEL_DBG);
 
-#define BLE_COMM_SHORT_INT_MIN  40
-#define BLE_COMM_SHORT_INT_MAX  50
-#define BLE_COMM_LONG_INT_MIN   400
-#define BLE_COMM_LONG_INT_MAX   500
+#define BLE_COMM_LONG_INT_MIN_MS   (400 / 1.25)
+#define BLE_COMM_LONG_INT_MAX_MS   (500 / 1.25)
 
 #define BLE_COMM_CONN_INT_UPDATE_TIMEOUT_MS    5000
 
@@ -196,10 +194,10 @@ int ble_comm_short_connection_interval(void)
 {
     int err;
     struct bt_le_conn_param param = {
-        .interval_min = BLE_COMM_SHORT_INT_MIN,
-        .interval_max = BLE_COMM_SHORT_INT_MAX,
-        .latency = 0,
-        .timeout = 500,
+        .interval_min = CONFIG_BT_PERIPHERAL_PREF_MIN_INT,
+        .interval_max = CONFIG_BT_PERIPHERAL_PREF_MAX_INT,
+        .latency = CONFIG_BT_PERIPHERAL_PREF_LATENCY,
+        .timeout = CONFIG_BT_PERIPHERAL_PREF_TIMEOUT,
     };
 
     // If someone explicitly requested short connection interval,
@@ -220,10 +218,10 @@ int ble_comm_long_connection_interval(void)
 {
     int err;
     struct bt_le_conn_param param = {
-        .interval_min = CONFIG_BT_PERIPHERAL_PREF_MIN_INT,
-        .interval_max = CONFIG_BT_PERIPHERAL_PREF_MAX_INT,
+        .interval_min = BLE_COMM_LONG_INT_MIN_MS,
+        .interval_max = BLE_COMM_LONG_INT_MAX_MS,
         .latency = CONFIG_BT_PERIPHERAL_PREF_LATENCY,
-        .timeout = CONFIG_BT_PERIPHERAL_PREF_TIMEOUT,
+        .timeout = 500,
     };
 
     LOG_DBG("Set long conection interval");

--- a/app/src/display_control.c
+++ b/app/src/display_control.c
@@ -15,9 +15,9 @@ LOG_MODULE_REGISTER(display_control, LOG_LEVEL_WRN);
 static void lvgl_render(struct k_work *item);
 
 typedef enum display_state {
-    AWAKE,
-    SLEEPING,
-    POWERED_OFF,
+    DISPLAY_STATE_AWAKE,
+    DISPLAY_STATE_SLEEPING,
+    DISPLAY_STATE_POWERED_OFF,
 } display_state_t;
 
 static const struct pwm_dt_spec display_blk = PWM_DT_SPEC_GET_OR(DT_ALIAS(display_blk), {});
@@ -28,7 +28,7 @@ static const struct device *touch_dev = DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_k
 K_WORK_DELAYABLE_DEFINE(lvgl_work, lvgl_render);
 
 static struct k_work_sync canel_work_sync;
-static display_state_t state;
+static display_state_t display_state;
 static bool first_render_since_poweron;
 static uint8_t last_brightness = 30;
 
@@ -47,17 +47,17 @@ void display_control_init(void)
         LOG_WRN("Device touch not ready.");
     }
 
-    state = SLEEPING;
+    display_state = DISPLAY_STATE_SLEEPING;
 }
 
 void display_control_sleep_ctrl(bool on)
 {
-    switch (state) {
-        case AWAKE:
+    switch (display_state) {
+        case DISPLAY_STATE_AWAKE:
             if (on) {
                 LOG_DBG("Display already awake");
             } else {
-                state = SLEEPING;
+                display_state = DISPLAY_STATE_SLEEPING;
                 display_blanking_on(display_dev);
                 // Suspend the display and touch chip
                 pm_device_action_run(display_dev, PM_DEVICE_ACTION_SUSPEND);
@@ -74,9 +74,9 @@ void display_control_sleep_ctrl(bool on)
                 lv_obj_invalidate(lv_scr_act());
             }
             break;
-        case SLEEPING:
+        case DISPLAY_STATE_SLEEPING:
             if (on) {
-                state = AWAKE;
+                display_state = DISPLAY_STATE_AWAKE;
                 // Resume the display and touch chip
                 pm_device_action_run(display_dev, PM_DEVICE_ACTION_RESUME);
                 pm_device_action_run(touch_dev, PM_DEVICE_ACTION_RESUME);
@@ -89,10 +89,10 @@ void display_control_sleep_ctrl(bool on)
                 display_blanking_off(display_dev);
                 k_work_schedule(&lvgl_work, K_MSEC(250));
             } else {
-                LOG_DBG("Display already sleeping");
+                LOG_DBG("Display already DISPLAY_STATE_sleeping");
             }
             break;
-        case POWERED_OFF:
+        case DISPLAY_STATE_POWERED_OFF:
             if (on) {
                 LOG_DBG("Display is OFF, power on before exiting sleep");
             } else {
@@ -104,29 +104,29 @@ void display_control_sleep_ctrl(bool on)
 
 void display_control_pwr_ctrl(bool on)
 {
-    switch (state) {
-        case AWAKE:
+    switch (display_state) {
+        case DISPLAY_STATE_AWAKE:
             if (on) {
-                LOG_DBG("Display awake, power already on");
+                LOG_DBG("Display DISPLAY_STATE_awake, power already on");
             } else {
-                LOG_DBG("Display awake, sleep before power off");
+                LOG_DBG("Display DISPLAY_STATE_awake, sleep before power off");
             }
             break;
-        case SLEEPING:
+        case DISPLAY_STATE_SLEEPING:
             if (on) {
-                LOG_DBG("Display sleeping, power already on");
+                LOG_DBG("Display DISPLAY_STATE_sleeping, power already on");
             } else {
                 if (device_is_ready(reg_dev)) {
-                    state = POWERED_OFF;
+                    display_state = DISPLAY_STATE_POWERED_OFF;
                     regulator_disable(reg_dev);
                     pm_device_action_run(display_dev, PM_DEVICE_ACTION_TURN_OFF);
                 }
             }
             break;
-        case POWERED_OFF:
+        case DISPLAY_STATE_POWERED_OFF:
             if (on) {
                 if (device_is_ready(reg_dev)) {
-                    state = SLEEPING;
+                    display_state = DISPLAY_STATE_SLEEPING;
                     regulator_enable(reg_dev);
                     pm_device_action_run(display_dev, PM_DEVICE_ACTION_TURN_ON);
                     first_render_since_poweron = true;
@@ -156,7 +156,7 @@ void display_control_set_brightness(uint8_t percent)
     // and we need to take that into consideration when choosing pwm period and pulse width.
     uint32_t pulse_width = percent * (display_blk.period / 100);
 
-    if (state != AWAKE && percent != 0) {
+    if (display_state != DISPLAY_STATE_AWAKE && percent != 0) {
         LOG_WRN("Setting brightness when display is off may cause issues with active/inactive state, make sure you know what you are doing.");
     }
 

--- a/app/src/display_control.c
+++ b/app/src/display_control.c
@@ -137,7 +137,9 @@ int display_control_pwr_ctrl(bool on)
             } else {
                 if (device_is_ready(reg_dev)) {
                     display_state = DISPLAY_STATE_POWERED_OFF;
+#ifndef CONFIG_BOARD_NATIVE_POSIX
                     regulator_disable(reg_dev);
+#endif
                     pm_device_action_run(display_dev, PM_DEVICE_ACTION_TURN_OFF);
                     res = 0;
                 }
@@ -147,7 +149,9 @@ int display_control_pwr_ctrl(bool on)
             if (on) {
                 if (device_is_ready(reg_dev)) {
                     display_state = DISPLAY_STATE_SLEEPING;
+#ifndef CONFIG_BOARD_NATIVE_POSIX
                     regulator_enable(reg_dev);
+#endif
                     pm_device_action_run(display_dev, PM_DEVICE_ACTION_TURN_ON);
                     first_render_since_poweron = true;
                     res = 0;

--- a/app/src/display_control.c
+++ b/app/src/display_control.c
@@ -14,6 +14,12 @@ LOG_MODULE_REGISTER(display_control, LOG_LEVEL_WRN);
 
 static void lvgl_render(struct k_work *item);
 
+typedef enum display_state {
+    AWAKE,
+    SLEEPING,
+    POWERED_OFF,
+} display_state_t;
+
 static const struct pwm_dt_spec display_blk = PWM_DT_SPEC_GET_OR(DT_ALIAS(display_blk), {});
 static const struct device *const reg_dev = DEVICE_DT_GET_OR_NULL(DT_PATH(regulator_3v3_ctrl));
 static const struct device *display_dev = DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_display));
@@ -22,7 +28,7 @@ static const struct device *touch_dev = DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_k
 K_WORK_DELAYABLE_DEFINE(lvgl_work, lvgl_render);
 
 static struct k_work_sync canel_work_sync;
-static bool is_on;
+static display_state_t state;
 static uint8_t last_brightness = 30;
 
 void display_control_init(void)
@@ -39,53 +45,93 @@ void display_control_init(void)
     if (!device_is_ready(touch_dev)) {
         LOG_WRN("Device touch not ready.");
     }
+
+    state = SLEEPING;
 }
 
-void display_control_power_on(bool on)
+void display_control_sleep_ctrl(bool on)
 {
-    if (on == is_on) {
-        return;
-    }
-    is_on = on;
-    if (on) {
-        // Turn on 3V3 regulator that powers display related stuff.
-#ifndef CONFIG_DISPLAY_FAST_WAKEUP
-        if (device_is_ready(reg_dev)) {
-            regulator_enable(reg_dev);
-            pm_device_action_run(display_dev, PM_DEVICE_ACTION_TURN_ON);
-        }
-#endif
-        // Resume the display and touch chip
-        pm_device_action_run(display_dev, PM_DEVICE_ACTION_RESUME);
-        pm_device_action_run(touch_dev, PM_DEVICE_ACTION_RESUME);
-        // Turn backlight on.
-        display_control_set_brightness(last_brightness);
-        display_blanking_off(display_dev);
-        k_work_schedule(&lvgl_work, K_MSEC(250));
-    } else {
-        display_blanking_on(display_dev);
-        // Suspend the display and touch chip
-        pm_device_action_run(display_dev, PM_DEVICE_ACTION_SUSPEND);
-        pm_device_action_run(touch_dev, PM_DEVICE_ACTION_SUSPEND);
+    switch (state) {
+        case AWAKE:
+            if (on) {
+                LOG_DBG("Display already awake");
+            } else {
+                state = SLEEPING;
+                display_blanking_on(display_dev);
+                // Suspend the display and touch chip
+                pm_device_action_run(display_dev, PM_DEVICE_ACTION_SUSPEND);
+                pm_device_action_run(touch_dev, PM_DEVICE_ACTION_SUSPEND);
 
-        // Turn off 3v3 regulator
-#ifndef CONFIG_DISPLAY_FAST_WAKEUP
-        if (device_is_ready(reg_dev)) {
-            regulator_disable(reg_dev);
-            pm_device_action_run(display_dev, PM_DEVICE_ACTION_TURN_OFF);
-        }
-#endif
-        // Turn off PWM peripheral as it consumes like 200-250uA
-        display_control_set_brightness(0);
-        // Cancel pending call to lv_task_handler
-        // Don't waste resosuces to rendering when display is off anyway.
-        k_work_cancel_delayable_sync(&lvgl_work, &canel_work_sync);
-        // Prepare for next call to lv_task_handler when screen is enabled again,
-        // Since the display will have been powered off, we need to tell LVGL
-        // to rerender the complete display.
-        lv_obj_invalidate(lv_scr_act());
+                // Turn off PWM peripheral as it consumes like 200-250uA
+                display_control_set_brightness(0);
+                // Cancel pending call to lv_task_handler
+                // Don't waste resosuces to rendering when display is off anyway.
+                k_work_cancel_delayable_sync(&lvgl_work, &canel_work_sync);
+                // Prepare for next call to lv_task_handler when screen is enabled again,
+                // Since the display will have been powered off, we need to tell LVGL
+                // to rerender the complete display.
+                lv_obj_invalidate(lv_scr_act());
+            }
+            break;
+        case SLEEPING:
+            if (on) {
+                state = AWAKE;
+                // Resume the display and touch chip
+                pm_device_action_run(display_dev, PM_DEVICE_ACTION_RESUME);
+                pm_device_action_run(touch_dev, PM_DEVICE_ACTION_RESUME);
+                // Turn backlight on.
+                display_control_set_brightness(last_brightness);
+                display_blanking_off(display_dev);
+                k_work_schedule(&lvgl_work, K_MSEC(250));
+            } else {
+                LOG_DBG("Display already sleeping");
+            }
+            break;
+        case POWERED_OFF:
+            if (on) {
+                LOG_DBG("Display is OFF, power on before exiting sleep");
+            } else {
+                LOG_DBG("Display is OFF, cannot enter sleep");
+            }
+            break;
     }
 }
+
+void display_control_pwr_ctrl(bool on)
+{
+    switch (state) {
+        case AWAKE:
+            if (on) {
+                LOG_DBG("Display awake, power already on");
+            } else {
+                LOG_DBG("Display awake, sleep before power off");
+            }
+            break;
+        case SLEEPING:
+            if (on) {
+                LOG_DBG("Display sleeping, power already on");
+            } else {
+                if (device_is_ready(reg_dev)) {
+                    state = POWERED_OFF;
+                    regulator_disable(reg_dev);
+                    pm_device_action_run(display_dev, PM_DEVICE_ACTION_TURN_OFF);
+                }
+            }
+            break;
+        case POWERED_OFF:
+            if (on) {
+                if (device_is_ready(reg_dev)) {
+                    state = SLEEPING;
+                    regulator_enable(reg_dev);
+                    pm_device_action_run(display_dev, PM_DEVICE_ACTION_TURN_ON);
+                }
+            } else {
+                LOG_DBG("Display is OFF, power already off.");
+            }
+            break;
+    }
+}
+
 
 uint8_t display_control_get_brightness(void)
 {
@@ -104,7 +150,7 @@ void display_control_set_brightness(uint8_t percent)
     // and we need to take that into consideration when choosing pwm period and pulse width.
     uint32_t pulse_width = percent * (display_blk.period / 100);
 
-    if (!is_on && percent != 0) {
+    if (state != AWAKE && percent != 0) {
         LOG_WRN("Setting brightness when display is off may cause issues with active/inactive state, make sure you know what you are doing.");
     }
 

--- a/app/src/display_control.h
+++ b/app/src/display_control.h
@@ -4,8 +4,8 @@
 #include <stdbool.h>
 
 void display_control_init(void);
-void display_control_sleep_ctrl(bool on);
-void display_control_pwr_ctrl(bool on);
+int display_control_sleep_ctrl(bool on);
+int display_control_pwr_ctrl(bool on);
 void display_control_set_brightness(uint8_t percent);
 uint8_t display_control_get_brightness(void);
 #endif

--- a/app/src/display_control.h
+++ b/app/src/display_control.h
@@ -4,7 +4,8 @@
 #include <stdbool.h>
 
 void display_control_init(void);
-void display_control_power_on(bool on);
+void display_control_sleep_ctrl(bool on);
+void display_control_pwr_ctrl(bool on);
 void display_control_set_brightness(uint8_t percent);
 uint8_t display_control_get_brightness(void);
 #endif

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -111,7 +111,7 @@ static void run_init_work(struct k_work *item)
     // Not to self, PWM consumes like 250uA...
     // Need to disable also when screen is off.
     display_control_init();
-    display_control_power_on(true);
+    display_control_sleep_ctrl(true);
 
     lv_indev_drv_init(&enc_drv);
     enc_drv.type = LV_INDEV_TYPE_ENCODER;

--- a/app/src/ram_retention_storage.c
+++ b/app/src/ram_retention_storage.c
@@ -177,6 +177,12 @@ void retained_update(void)
     retained.crc = sys_cpu_to_le32(crc);
 }
 
+void retained_reset(void)
+{
+    memset(&retained, 0, sizeof(retained));
+    retained_update();
+}
+
 #else
 struct retained_data retained;
 bool retained_validate()
@@ -187,5 +193,9 @@ bool retained_validate()
 void retained_update(void)
 {
 
+}
+
+void retained_reset(void)
+{
 }
 #endif

--- a/app/src/ram_retention_storage.h
+++ b/app/src/ram_retention_storage.h
@@ -13,6 +13,7 @@
 struct retained_data {
     time_t current_time_seconds;
     uint64_t wakeup_time;
+    uint64_t display_off_time;
 
     /* The uptime from the current session the last time the
      * retained data was updated.

--- a/app/src/ram_retention_storage.h
+++ b/app/src/ram_retention_storage.h
@@ -55,4 +55,6 @@ bool retained_validate(void);
  */
 void retained_update(void);
 
+void retained_reset(void);
+
 #endif /* RETAINED_H_ */

--- a/app/src/ui/watchfaces/zsw_watchface_digital_ui.c
+++ b/app/src/ui/watchfaces/zsw_watchface_digital_ui.c
@@ -414,7 +414,7 @@ void watchface_show(void)
 
     // Just use a default dummy image by default
     const lv_img_dsc_t *icon = zsw_ui_utils_icon_from_weather_code(802, &icon_color);
-    lv_img_set_src(ui_weather_icon, &icon);
+    lv_img_set_src(ui_weather_icon, icon);
     lv_obj_set_width(ui_weather_icon, LV_SIZE_CONTENT);
     lv_obj_set_height(ui_weather_icon, LV_SIZE_CONTENT);
     lv_obj_set_x(ui_weather_icon, -12);

--- a/app/src/zsw_imu.c
+++ b/app/src/zsw_imu.c
@@ -450,7 +450,7 @@ static void configure_no_motion(struct bmi2_sens_config *config)
 {
     // 1LSB equals 20ms. Default is 100ms, setting to 80ms.
     // Max value is 163 seconds, hence below calc. We want max.
-    config->cfg.no_motion.duration = (120 * 1000) / 20;
+    config->cfg.no_motion.duration = (60 * 1000) / 20;
 }
 
 static bool is_sensor_feature(uint8_t sensor_id)

--- a/app/src/zsw_imu.c
+++ b/app/src/zsw_imu.c
@@ -450,7 +450,7 @@ static void configure_no_motion(struct bmi2_sens_config *config)
 {
     // 1LSB equals 20ms. Default is 100ms, setting to 80ms.
     // Max value is 163 seconds, hence below calc. We want max.
-    config->cfg.no_motion.duration = (60 * 1000) / 20;
+    config->cfg.no_motion.duration = (30 * 1000) / 20;
 }
 
 static bool is_sensor_feature(uint8_t sensor_id)

--- a/app/src/zsw_imu.h
+++ b/app/src/zsw_imu.h
@@ -2,6 +2,19 @@
 #define ZSW_IMU_H_
 
 #include <zephyr/drivers/sensor.h>
+#include <bmi270.h>
+
+typedef enum zsw_imu_feature_t {
+    ZSW_IMU_FEATURE_ACCEL = BMI2_ACCEL,
+    ZSW_IMU_FEATURE_GYRO = BMI2_GYRO,
+    ZSW_IMU_FEATURE_STEP_COUNTER = BMI2_STEP_COUNTER,
+    ZSW_IMU_FEATURE_SIG_MOTION = BMI2_SIG_MOTION,
+    ZSW_IMU_FEATURE_ANY_MOTION = BMI2_ANY_MOTION,
+    ZSW_IMU_FEATURE_STEP_ACTIVITY = BMI2_STEP_ACTIVITY,
+    ZSW_IMU_FEATURE_WRIST_GESTURE = BMI2_WRIST_GESTURE,
+    ZSW_IMU_FEATURE_WRIST_WEAR_WAKE_UP = BMI2_WRIST_WEAR_WAKE_UP,
+    ZSW_IMU_FEATURE_NO_MOTION = BMI2_NO_MOTION,
+} zsw_imu_feature_t;
 
 typedef enum zsw_imu_evt_type_t {
     ZSW_IMU_EVT_TYPE_XYZ,
@@ -64,6 +77,8 @@ int zsw_imu_fetch_num_steps(uint32_t *num_steps);
 
 int zsw_imu_reset_step_count(void);
 
-int zsw_imu_any_motion_int_set_enabled(bool enabled);
+int zsw_imu_feature_enable(zsw_imu_feature_t feature, bool int_en);
+
+int zsw_imu_feature_disable(zsw_imu_feature_t feature);
 
 #endif

--- a/app/src/zsw_power_manager.c
+++ b/app/src/zsw_power_manager.c
@@ -31,7 +31,7 @@ LOG_MODULE_REGISTER(zsw_power_manager, LOG_LEVEL_INF);
 #ifdef CONFIG_BOARD_NATIVE_POSIX
 #define IDLE_TIMEOUT_SECONDS    UINT32_MAX
 #else
-#define IDLE_TIMEOUT_SECONDS    30
+#define IDLE_TIMEOUT_SECONDS    20
 #endif
 
 static void enter_active(void);


### PR DESCRIPTION
Some really nice power consumption improvements, especially when the watch is left stationary (not worn).

... and some other cleanup during the way.

Uses accelerometer NO_MOTION and ANY_MOTION combo to determine when to power off the display completely (turning off 3V3 regulator).

In case of NO_MOTION (stationary) and an ANY_MOTION happens, we will initialize the display (saves 500ms) meaning if a wakeup gesture is triggered after, display is already configured, display will still wakup almost as fast as it would without powering off 3v3.

I have also added some debug info in `system info app` that shows the time 3V3 regulator has been disabled.