### PR TITLE
Feature apps selectable

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -3,6 +3,48 @@ menu "Zephyr Kernel"
 endmenu
 
 menu "ZSWatch"
+    menu "Applications"
+        config APPLICATIONS_USE_2048
+            bool
+        prompt "Activate the application '2048'"
+        default ny
+
+        config APPLICATIONS_USE_ACCELEROMETER
+            bool
+        prompt "Activate the application 'Accelerometer'"
+        default y
+
+        config APPLICATIONS_USE_BATTERY
+            bool
+        prompt "Activate the application 'Battery'"
+        default y
+
+        config APPLICATIONS_USE_COMPASS
+            bool
+        prompt "Activate the application 'Compass'"
+        default y
+
+        config APPLICATIONS_USE_INFO
+            bool
+        prompt "Activate the application 'Info'"
+        default y
+
+        config APPLICATIONS_USE_QR_CODE
+            bool
+        prompt "Activate the application 'QR-Code'"
+        default y
+
+        config APPLICATIONS_USE_X_RAY
+            bool
+        prompt "Activate the application 'X-Ray'"
+        default y
+
+        config APPLICATIONS_USE_ZDS
+            bool
+        prompt "Activate the application 'ZDS'"
+        default y
+    endmenu
+
     config DISABLE_PAIRING_REQUIRED
         bool
     prompt "Disable encryption required for BLE connection (pairing/bonding)"

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -7,7 +7,7 @@ menu "ZSWatch"
         config APPLICATIONS_USE_2048
             bool
         prompt "Activate the application '2048'"
-        default ny
+        default y
 
         config APPLICATIONS_USE_ACCELEROMETER
             bool
@@ -32,17 +32,18 @@ menu "ZSWatch"
         config APPLICATIONS_USE_QR_CODE
             bool
         prompt "Activate the application 'QR-Code'"
-        default y
+        default n
 
         config APPLICATIONS_USE_X_RAY
             bool
         prompt "Activate the application 'X-Ray'"
-        default y
+        default n
 
         config APPLICATIONS_USE_ZDS
             bool
         prompt "Activate the application 'ZDS'"
         default y
+        select APPLICATIONS_USE_ACCELEROMETER
     endmenu
 
     config DISABLE_PAIRING_REQUIRED

--- a/app/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/app/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -115,13 +115,6 @@
         irq-gpios = <&gpio0 24 0>;
     };
 
-    max30101@57 {
-        status = "okay";
-        compatible = "maxim,max30101";
-        reg = <0x57>;
-        //irq-gpios = <&gpio0 22 GPIO_ACTIVE_HIGH; // Not supported by Zephyr driver
-    };
-
     bmp581: bmp581@47 {
         compatible = "bosch,bmp581";
         reg = <0x47>;

--- a/app/src/applications/2048/CMakeLists.txt
+++ b/app/src/applications/2048/CMakeLists.txt
@@ -1,8 +1,10 @@
-FILE(GLOB app_sources *.c)
-target_sources(app PRIVATE ${app_sources})
+if(CONFIG_APPLICATIONS_USE_2048)
+    FILE(GLOB app_sources *.c)
+    target_sources(app PRIVATE ${app_sources})
 
-set(LV_USE_100ASK_2048 "1")
-target_include_directories(app PRIVATE 2048_lib/src/lv_100ask_2048)
-target_sources(app PRIVATE 2048_lib/src/lv_100ask_2048/lv_100ask_2048.c)
-# File contains some build warnings, ignore those.
-set_source_files_properties(2048_lib/src/lv_100ask_2048/lv_100ask_2048.c TARGET_DIRECTORY app PROPERTIES COMPILE_OPTIONS -w)
+    set(LV_USE_100ASK_2048 "1")
+    target_include_directories(app PRIVATE 2048_lib/src/lv_100ask_2048)
+    target_sources(app PRIVATE 2048_lib/src/lv_100ask_2048/lv_100ask_2048.c)
+    # File contains some build warnings, ignore those.
+    set_source_files_properties(2048_lib/src/lv_100ask_2048/lv_100ask_2048.c TARGET_DIRECTORY app PROPERTIES COMPILE_OPTIONS -w)
+endif()

--- a/app/src/applications/accelerometer/CMakeLists.txt
+++ b/app/src/applications/accelerometer/CMakeLists.txt
@@ -1,2 +1,4 @@
-FILE(GLOB app_sources *.c)
-target_sources(app PRIVATE ${app_sources})
+if(CONFIG_APPLICATIONS_USE_ACCELEROMETER)
+    FILE(GLOB app_sources *.c)
+    target_sources(app PRIVATE ${app_sources})
+endif()

--- a/app/src/applications/battery/CMakeLists.txt
+++ b/app/src/applications/battery/CMakeLists.txt
@@ -1,2 +1,4 @@
-FILE(GLOB app_sources *.c)
-target_sources(app PRIVATE ${app_sources})
+if(CONFIG_APPLICATIONS_USE_BATTERY)
+    FILE(GLOB app_sources *.c)
+    target_sources(app PRIVATE ${app_sources})
+endif()

--- a/app/src/applications/compass/CMakeLists.txt
+++ b/app/src/applications/compass/CMakeLists.txt
@@ -1,2 +1,4 @@
-FILE(GLOB app_sources *.c)
-target_sources(app PRIVATE ${app_sources})
+if(CONFIG_APPLICATIONS_USE_COMPASS)
+    FILE(GLOB app_sources *.c)
+    target_sources(app PRIVATE ${app_sources})
+endif()

--- a/app/src/applications/info/CMakeLists.txt
+++ b/app/src/applications/info/CMakeLists.txt
@@ -1,2 +1,4 @@
-FILE(GLOB app_sources *.c)
-target_sources(app PRIVATE ${app_sources})
+if(CONFIG_APPLICATIONS_USE_INFO)
+    FILE(GLOB app_sources *.c)
+    target_sources(app PRIVATE ${app_sources})
+endif()

--- a/app/src/applications/qr_code/CMakeLists.txt
+++ b/app/src/applications/qr_code/CMakeLists.txt
@@ -1,4 +1,4 @@
-if (CONFIG_DEMO_BUILD)
-FILE(GLOB app_sources *.c)
-target_sources(app PRIVATE ${app_sources})
+if(CONFIG_APPLICATIONS_QR_CODE)
+    FILE(GLOB app_sources *.c)
+    target_sources(app PRIVATE ${app_sources})
 endif()

--- a/app/src/applications/x_ray/CMakeLists.txt
+++ b/app/src/applications/x_ray/CMakeLists.txt
@@ -1,4 +1,4 @@
-if (CONFIG_DEMO_BUILD)
-FILE(GLOB app_sources *.c)
-target_sources(app PRIVATE ${app_sources})
+if(CONFIG_APPLICATIONS_X_RAY)
+    FILE(GLOB app_sources *.c)
+    target_sources(app PRIVATE ${app_sources})
 endif()

--- a/app/src/applications/zds/CMakeLists.txt
+++ b/app/src/applications/zds/CMakeLists.txt
@@ -1,2 +1,4 @@
-FILE(GLOB app_sources *.c)
-target_sources(app PRIVATE ${app_sources})
+if(CONFIG_APPLICATIONS_ZDS)
+    FILE(GLOB app_sources *.c)
+    target_sources(app PRIVATE ${app_sources})
+endif()

--- a/app/src/applications/zds/CMakeLists.txt
+++ b/app/src/applications/zds/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(CONFIG_APPLICATIONS_ZDS)
+if(CONFIG_APPLICATIONS_USE_ZDS)
     FILE(GLOB app_sources *.c)
     target_sources(app PRIVATE ${app_sources})
 endif()

--- a/app/src/events/accel_event.c
+++ b/app/src/events/accel_event.c
@@ -5,6 +5,10 @@ ZBUS_CHAN_DEFINE(accel_data_chan,
                  struct accel_event,
                  NULL,
                  NULL,
-                 ZBUS_OBSERVERS(watchface_accel_lis, power_manager_accel_lis, zds_app_accel_lis),
+                 #ifdef CONFIG_APPLICATIONS_USE_ACCELEROMETER
+                    ZBUS_OBSERVERS(watchface_accel_lis, power_manager_accel_lis, zds_app_accel_lis),
+                 #else
+                    ZBUS_OBSERVERS(watchface_accel_lis, power_manager_accel_lis),
+                 #endif
                  ZBUS_MSG_INIT()
                 );

--- a/app/src/events/battery_event.c
+++ b/app/src/events/battery_event.c
@@ -5,6 +5,10 @@ ZBUS_CHAN_DEFINE(battery_sample_data_chan,
                  struct battery_sample_event,
                  NULL,
                  NULL,
-                 ZBUS_OBSERVERS(watchface_battery_event, zsw_phone_app_publisher_battery_event, battery_app_battery_event),
+                 #ifdef CONFIG_APPLICATIONS_USE_BATTERY
+                    ZBUS_OBSERVERS(watchface_battery_event, zsw_phone_app_publisher_battery_event, battery_app_battery_event),
+                 #else
+                    ZBUS_OBSERVERS(watchface_battery_event, zsw_phone_app_publisher_battery_event),
+                 #endif
                  ZBUS_MSG_INIT()
                 );


### PR DESCRIPTION
Make the apps selectable via Kconfig instead of manipulating the CMakeLists. Enabled by default:

- Game 2048
- Accelerometer
- Battery
- Compass
- Info
- ZDS