### PR TITLE
Feature add apds 9306 support

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -7,7 +7,7 @@ menu "ZSWatch"
         config APPLICATIONS_USE_2048
             bool
         prompt "Activate the application '2048'"
-        default ny
+        default y
 
         config APPLICATIONS_USE_ACCELEROMETER
             bool
@@ -32,12 +32,12 @@ menu "ZSWatch"
         config APPLICATIONS_USE_QR_CODE
             bool
         prompt "Activate the application 'QR-Code'"
-        default y
+        default n
 
         config APPLICATIONS_USE_X_RAY
             bool
         prompt "Activate the application 'X-Ray'"
-        default y
+        default n
 
         config APPLICATIONS_USE_ZDS
             bool

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -3,6 +3,48 @@ menu "Zephyr Kernel"
 endmenu
 
 menu "ZSWatch"
+    menu "Applications"
+        config APPLICATIONS_USE_2048
+            bool
+        prompt "Activate the application '2048'"
+        default ny
+
+        config APPLICATIONS_USE_ACCELEROMETER
+            bool
+        prompt "Activate the application 'Accelerometer'"
+        default y
+
+        config APPLICATIONS_USE_BATTERY
+            bool
+        prompt "Activate the application 'Battery'"
+        default y
+
+        config APPLICATIONS_USE_COMPASS
+            bool
+        prompt "Activate the application 'Compass'"
+        default y
+
+        config APPLICATIONS_USE_INFO
+            bool
+        prompt "Activate the application 'Info'"
+        default y
+
+        config APPLICATIONS_USE_QR_CODE
+            bool
+        prompt "Activate the application 'QR-Code'"
+        default y
+
+        config APPLICATIONS_USE_X_RAY
+            bool
+        prompt "Activate the application 'X-Ray'"
+        default y
+
+        config APPLICATIONS_USE_ZDS
+            bool
+        prompt "Activate the application 'ZDS'"
+        default y
+    endmenu
+
     config DISABLE_PAIRING_REQUIRED
         bool
     prompt "Disable encryption required for BLE connection (pairing/bonding)"

--- a/app/boards/arm/zswatch_nrf5340/zswatch_nrf5340_cpuapp_3.overlay
+++ b/app/boards/arm/zswatch_nrf5340/zswatch_nrf5340_cpuapp_3.overlay
@@ -79,6 +79,11 @@
         int1-gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
         int2-gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
     };
+
+    apds9306: apds9306@52 {
+        compatible = "avago,apds9306";
+        reg = <0x52>;
+    };
 };
 
 &spi4  {

--- a/app/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/app/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -115,13 +115,6 @@
         irq-gpios = <&gpio0 24 0>;
     };
 
-    max30101@57 {
-        status = "okay";
-        compatible = "maxim,max30101";
-        reg = <0x57>;
-        //irq-gpios = <&gpio0 22 GPIO_ACTIVE_HIGH; // Not supported by Zephyr driver
-    };
-
     bmp581: bmp581@47 {
         compatible = "bosch,bmp581";
         reg = <0x47>;

--- a/app/drivers/CMakeLists.txt
+++ b/app/drivers/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(display)
 add_subdirectory(input)
-add_subdirectory(sensor/apds9306)
+
+add_subdirectory_ifdef(CONFIG_SENSOR sensor)

--- a/app/drivers/CMakeLists.txt
+++ b/app/drivers/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(display)
 add_subdirectory(input)
+add_subdirectory(sensor/apds9306)

--- a/app/drivers/Kconfig
+++ b/app/drivers/Kconfig
@@ -1,2 +1,6 @@
 rsource "display/Kconfig"
 rsource "input/Kconfig"
+
+menu "Drivers"
+    rsource "sensor/Kconfig"
+endmenu

--- a/app/drivers/sensor/CMakeLists.txt
+++ b/app/drivers/sensor/CMakeLists.txt
@@ -3,4 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# TODO:
+# Weird compilation issue when not using
+# zephyr_library()
+# zephyr_library_sources(apds9306.c)
+#
+# -> ..add_library cannot create target "..__app__drivers__sensor" because another
+# -> target with the same name already exists.  The existing target is a static...
+#
 add_subdirectory_ifdef(CONFIG_APDS9306 apds9306)

--- a/app/drivers/sensor/CMakeLists.txt
+++ b/app/drivers/sensor/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2023, Daniel Kampert
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+add_subdirectory_ifdef(CONFIG_APDS9306 apds9306)

--- a/app/drivers/sensor/Kconfig
+++ b/app/drivers/sensor/Kconfig
@@ -1,0 +1,3 @@
+if SENSOR
+    rsource "apds9306/Kconfig"
+endif # SENSOR

--- a/app/drivers/sensor/apds9306/CMakeLists.txt
+++ b/app/drivers/sensor/apds9306/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, Daniel Kampert
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# TODO: Doesn´t work with CMakeList.txt of the drivers directory -> Check it
+#zephyr_library()
+
+zephyr_library_sources(apds9306.c)

--- a/app/drivers/sensor/apds9306/CMakeLists.txt
+++ b/app/drivers/sensor/apds9306/CMakeLists.txt
@@ -6,4 +6,4 @@
 # TODO: Doesn´t work with CMakeList.txt of the drivers directory -> Check it
 #zephyr_library()
 
-zephyr_library_sources(apds9306.c)
+zephyr_sources(apds9306.c)

--- a/app/drivers/sensor/apds9306/Kconfig
+++ b/app/drivers/sensor/apds9306/Kconfig
@@ -4,9 +4,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-config APDS9306
-	bool "APDS9306 light sensor"
+menuconfig APDS9306
+	bool "APDS9306 Sensor"
 	default y
+	# TODO
+	#depends on DT_HAS_AVAGO_APDS9306_ENABLED
 	select I2C
 	help
-	  Enable the driver for the APDS9306 digital light sensor.
+	  	Enable the driver for the APDS9306 digital light sensor.
+
+if APDS9306
+	config APDS9306_IS_APDS9306_065
+		bool "Enable this option if you are using the APDS-9306-065"
+		default n
+
+endif

--- a/app/drivers/sensor/apds9306/Kconfig
+++ b/app/drivers/sensor/apds9306/Kconfig
@@ -1,0 +1,12 @@
+# APDS-9306 light sensor configuration options.
+
+# Copyright (c) 2023, Daniel Kampert
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config APDS9306
+	bool "APDS9306 light sensor"
+	default y
+	select I2C
+	help
+	  Enable the driver for the APDS9306 digital light sensor.

--- a/app/drivers/sensor/apds9306/Kconfig
+++ b/app/drivers/sensor/apds9306/Kconfig
@@ -5,17 +5,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig APDS9306
-	bool "APDS9306 Sensor"
-	default y
-	# TODO
-	#depends on DT_HAS_AVAGO_APDS9306_ENABLED
-	select I2C
-	help
-	  	Enable the driver for the APDS9306 digital light sensor.
+    bool "APDS9306 Sensor"
+    default y
+    # TODO
+    #depends on DT_HAS_AVAGO_APDS9306_ENABLED
+    select I2C
+    help
+          Enable the driver for the APDS9306 digital light sensor.
 
 if APDS9306
-	config APDS9306_IS_APDS9306_065
-		bool "Enable this option if you are using the APDS-9306-065"
-		default n
+    config APDS9306_IS_APDS9306_065
+        bool "Enable this option if you are using the APDS-9306-065"
+        default n
 
 endif

--- a/app/drivers/sensor/apds9306/apds9306.c
+++ b/app/drivers/sensor/apds9306/apds9306.c
@@ -1,4 +1,4 @@
-/* apds9306.c - Driver for Avago APDS-9306 light sensor. */
+/* apds9306.c - Driver for Avago APDS9306 light sensor. */
 
 /*
  * Copyright (c) 2023, Daniel Kampert
@@ -6,72 +6,299 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT avago_apds9306
-
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/i2c.h>
-#include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
 
-//LOG_MODULE_REGISTER(apds9306, CONFIG_SENSOR_LOG_LEVEL);
-LOG_MODULE_REGISTER(apds9306, LOG_LEVEL_INF);
+#include "apds9306.h"
+
+#define APDS9306_REGISTER_MAIN_CTRL         0x00
+#define APDS9306_REGISTER_ALS_MEAS_RATE     0x04
+#define APDS9306_REGISTER_ALS_GAIN          0x05
+#define APDS9306_REGISTER_PART_ID           0x06
+#define APDS9306_REGISTER_MAIN_STATUS       0x07
+#define APDS9306_REGISTER_CLEAR_DATA_0      0x0A
+#define APDS9306_REGISTER_CLEAR_DATA_1      0x0B
+#define APDS9306_REGISTER_CLEAR_DATA_2      0x0C
+#define APDS9306_REGISTER_ALS_DATA_0        0x0D
+#define APDS9306_REGISTER_ALS_DATA_1        0x0E
+#define APDS9306_REGISTER_ALS_DATA_2        0x0F
+#define APDS9306_REGISTER_INT_CFG           0x19
+#define APDS9306_REGISTER_INT_PERSISTENCE   0x1A
+#define APDS9306_REGISTER_ALS_THRES_UP_0    0x21
+#define APDS9306_REGISTER_ALS_THRES_UP_1    0x22
+#define APDS9306_REGISTER_ALS_THRES_UP_2    0x23
+#define APDS9306_REGISTER_ALS_THRES_LOW_0   0x24
+#define APDS9306_REGISTER_ALS_THRES_LOW_1   0x25
+#define APDS9306_REGISTER_ALS_THRES_LOW_2   0x26
+#define APDS9306_REGISTER_ALS_THRES_VAR     0x27
+
+#define ADPS9306_BIT_ALS_EN                 (0x01 << 0x01)
+#define ADPS9306_BIT_ALS_DATA_STATUS        (0x01 << 0x03)
+#define APDS9306_BIT_SW_RESET               (0x01 << 0x04)
+#define ADPS9306_BIT_ALS_INTERRUPT_STATUS   (0x01 << 0x03)
+#define APDS9306_BIT_POWER_ON_STATUS        (0x01 << 0x05)
+
+#if CONFIG_APDS9306_IS_APDS9306_065
+    #define APDS_9306_CHIP_ID               0xB3
+#else
+    #define APDS_9306_CHIP_ID               0xB1
+#endif
+
+LOG_MODULE_REGISTER(apds9306, CONFIG_SENSOR_LOG_LEVEL);
 
 #if(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 0)
     #warning "apds9306 driver enabled without any devices"
 #endif
 
-struct apds9306_data_t {
-	int16_t light;
+struct apds9306_data {
+	uint32_t light;
 };
 
-struct apds9306_config_t {
+struct apds9306_config {
 	struct i2c_dt_spec i2c;
+    uint8_t Resolution;
+    uint8_t Rate;
+    uint8_t Gain;
 };								
+
+/** @brief          Enable the ALS measurement.
+ *  @param p_Dev    Pointer to sensor device
+ *  @return         0 when successful
+*/
+static int apds9306_enable(const struct device* p_Dev)
+{
+	const struct apds9306_config* Config = p_Dev->config;
+
+	if(i2c_reg_update_byte_dt(&Config->i2c, APDS9306_REGISTER_MAIN_CTRL, ADPS9306_BIT_ALS_EN, ADPS9306_BIT_ALS_EN))
+    {
+		return -EIO;
+	}
+
+    return 0;
+}
+
+/** @brief          Disable the ALS measurement.
+ *  @param p_Dev    Pointer to sensor device
+ *  @return         0 when successful
+*/
+static int apds9306_standby(const struct device* p_Dev)
+{
+	const struct apds9306_config* Config = p_Dev->config;
+
+	if(i2c_reg_update_byte_dt(&Config->i2c, APDS9306_REGISTER_MAIN_CTRL, ADPS9306_BIT_ALS_EN, 0x00))
+    {
+		LOG_ERR("Can not disable ALS!");
+		return -EIO;
+	}
+
+    return 0;
+}
+
+/** @brief          Start and wait for a new light measurement.
+ *  @param p_Dev    Pointer to sensor device
+ *  @param p_Value  Pointer to sensor result
+ *  @return         0 when successful
+*/
+static int apds9306_read_light(const struct device* p_Dev, uint32_t* p_Value)
+{
+	int Error;
+	const struct apds9306_config* Config = p_Dev->config;
+	uint8_t Buffer[3];
+    uint8_t Temp;
+    uint8_t Register = APDS9306_REGISTER_ALS_DATA_0;
+    uint32_t Now;
+
+    LOG_DBG("Start a new measurement...");
+    if(apds9306_enable(p_Dev) != 0)
+    {
+		LOG_ERR("Can not enable ALS!");
+		return -EIO;
+    }
+
+    // Wait for the oscillator power up. This needs typically 5 ms, but we wait a bit longer to be sure.
+    // TODO: Better
+    k_msleep(400);
+
+    // Wait for the end of the measurement.
+    Now = k_uptime_get_32();
+    do
+    {
+        if(i2c_reg_read_byte_dt(&Config->i2c, APDS9306_REGISTER_MAIN_STATUS, &Temp))
+        {
+            LOG_ERR("Failed to read ALS status!");
+            return -EIO;
+        }
+
+        // We wait 100 ms maximum for the device to become ready.
+        if((k_uptime_get_32() - Now) > 500)
+        {
+            LOG_ERR("Sensor timeout!");
+            return -EIO;
+        }
+
+        k_msleep(10);
+    } while(Temp & ADPS9306_BIT_ALS_DATA_STATUS);
+
+    if(apds9306_standby(p_Dev) != 0)
+    {
+		LOG_ERR("Can not disable ALS!");
+		return -EIO;
+    }
+
+    // Read the results.
+	Error = i2c_write_read_dt(&Config->i2c, &Register, sizeof(Register), &Buffer, sizeof(Buffer));
+	if(Error < 0)
+    {
+		return Error;
+	}
+    
+    *p_Value = sys_get_le24(Buffer);
+
+	return 0;
+}
+
+static int apds9306_attr_set(const struct device* p_Dev, enum sensor_channel Channel, enum sensor_attribute Attribute, const struct sensor_value* p_Value)
+{
+    uint8_t Mask;
+    uint8_t Value;
+    uint8_t Register;
+	const struct apds9306_config* Config = p_Dev->config;
+
+	__ASSERT_NO_MSG(p_Value != NULL);
+
+	if(Channel != SENSOR_CHAN_LIGHT)
+    {
+		return -ENOTSUP;
+	}
+
+	if(Attribute == SENSOR_ATTR_SAMPLING_FREQUENCY)
+    {
+        Register = APDS9306_REGISTER_ALS_MEAS_RATE;
+        Mask = (0x07) << 0x00;
+        Value = p_Value->val1 & 0x07;
+    }
+    else if(Attribute == SENSOR_APDS9306_ATTR_GAIN)
+    {
+        Register = APDS9306_REGISTER_ALS_GAIN;
+        Mask = (0x07) << 0x00;
+        Value = p_Value->val1 & 0x07;
+    }
+    else if(Attribute == SENSOR_APDS9306_ATTR_RESOLUTION)
+    {
+        Register = APDS9306_REGISTER_ALS_MEAS_RATE;
+        Mask = (0x07) << 0x04;
+        Value = (p_Value->val1 & 0x07) << 0x04;
+    }
+    else
+    {
+        return -ENOTSUP;
+    }
+
+	if(i2c_reg_update_byte_dt(&Config->i2c, Register, Mask, Value))
+    {
+		LOG_ERR("Failed to set sensor attribute!");
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int apds9306_attr_get(const struct device* p_Dev, enum sensor_channel Channel, enum sensor_attribute Attribute, struct sensor_value* p_Value)
+{
+    uint8_t Mask;
+    uint8_t Value;
+    uint8_t Register;
+	const struct apds9306_config* Config = p_Dev->config;
+
+	__ASSERT_NO_MSG(p_Value != NULL);
+
+	if(Channel != SENSOR_CHAN_LIGHT)
+    {
+		return -ENOTSUP;
+	}
+
+	if(Attribute == SENSOR_ATTR_SAMPLING_FREQUENCY)
+    {
+        Register = APDS9306_REGISTER_ALS_MEAS_RATE;
+        Mask = 0x00;
+    }
+    else if(Attribute == SENSOR_APDS9306_ATTR_GAIN)
+    {
+        Register = APDS9306_REGISTER_ALS_GAIN;
+        Mask = 0x00;
+    }
+    else if(Attribute == SENSOR_APDS9306_ATTR_RESOLUTION)
+    {
+        Register = APDS9306_REGISTER_ALS_MEAS_RATE;
+        Mask = 0x04;
+    }
+    else
+    {
+        return -ENOTSUP;
+    }
+
+	if(i2c_reg_read_byte_dt(&Config->i2c, Register, &Value))
+    {
+		LOG_ERR("Failed to read sensor attribute!");
+		return -EIO;
+	}
+
+    LOG_DBG("Attribute value: %u", Value);
+
+    p_Value->val1 = (Value >> Mask) & 0x07;
+    p_Value->val2 = 0;
+
+	return 0;
+}
 
 static int apds9306_sample_fetch(const struct device* p_Dev, enum sensor_channel Channel)
 {
-	struct apds9306_data *data = p_Dev->data;
-	const struct apds9306_config_t *cfg = p_Dev->config;
+    int Error;
+    uint32_t Value;
+	struct apds9306_data* Data = p_Dev->data;
 	enum pm_device_state pm_state;
-	int ret;
 
 	(void)pm_device_state_get(p_Dev, &pm_state);
 	if(pm_state != PM_DEVICE_STATE_ACTIVE)
     {
-		ret = -EIO;
-		return ret;
+		return -EIO;
 	}
 
-	switch(Channel)
+	if((Channel != SENSOR_CHAN_ALL) && (Channel != SENSOR_CHAN_LIGHT))
     {
-        case SENSOR_CHAN_ALL:
-        case SENSOR_CHAN_LIGHT:
-        {
-            //ret = lm75_fetch_temp(cfg, data);
-            break;
-        }
-        default:
-        {
-            ret = -ENOTSUP;
-            break;
-        }
+		return -ENOTSUP;
 	}
 
-	return ret;
+    Error = apds9306_read_light(p_Dev, &Value);
+    if(Error < 0)
+    {
+        return Error;
+    }
+
+    Data->light = Value;
+
+    LOG_DBG("Sensor value: %u", Data->light);
+
+	return 0;
 }
 
 static int apds9306_channel_get(const struct device* p_Dev, enum sensor_channel Channel, struct sensor_value* p_Value)
 {
-	struct apds9306_data *data = p_Dev->data;
+	struct apds9306_data* Data = p_Dev->data;
 
 	switch(Channel)
     {
         case SENSOR_CHAN_LIGHT:
         {
+            p_Value->val1 = Data->light;
+            p_Value->val2 = 0;
+
             return 0;
         }
         default:
@@ -81,18 +308,93 @@ static int apds9306_channel_get(const struct device* p_Dev, enum sensor_channel 
 	}
 }
 
+static int apds9306_sensor_setup(const struct device* p_Dev)
+{
+    uint32_t Now;
+	uint8_t Temp;
+	const struct apds9306_config* Config = p_Dev->config;
+
+    // Wait for the device to become ready after a power cycle.
+    Now = k_uptime_get_32();
+    do
+    {
+        i2c_reg_read_byte_dt(&Config->i2c, APDS9306_REGISTER_MAIN_STATUS, &Temp);
+
+        // We wait 100 ms maximum for the device to become ready.
+        if((k_uptime_get_32() - Now) > 100)
+        {
+            LOG_ERR("Sensor timeout!");
+            return -EIO;
+        }
+
+        k_msleep(10);
+    } while(Temp & APDS9306_BIT_POWER_ON_STATUS);
+
+	if(i2c_reg_read_byte_dt(&Config->i2c, APDS9306_REGISTER_PART_ID, &Temp))
+    {
+		LOG_ERR("Failed reading chip id!");
+		return -EIO;
+	}
+
+	if(Temp != APDS_9306_CHIP_ID)
+    {
+		LOG_ERR("Invalid chip id! Found 0x%X, expect 0x%X", Temp, APDS_9306_CHIP_ID);
+		return -EIO;
+	}
+
+	// Reset the sensor.
+	if(i2c_reg_write_byte_dt(&Config->i2c, APDS9306_REGISTER_MAIN_CTRL, APDS9306_BIT_SW_RESET))
+    {
+		LOG_ERR("Can not reset the sensor!");
+		return -EIO;
+	}
+
+    k_msleep(10);
+
+	return 0;
+}
+
+static int apds9306_interrupt_setup(const struct device* p_Dev)
+{
+    // TODO
+
+	return 0;
+}
+
 static const struct sensor_driver_api apds9306_driver_api = {
+    .attr_set = apds9306_attr_set,
+	.attr_get = apds9306_attr_get,
 	.sample_fetch = apds9306_sample_fetch,
 	.channel_get = apds9306_channel_get,
 };
 
 static int apds9306_init(const struct device* p_Dev)
 {
-	int ret = 0;
+	const struct apds9306_config* Config = p_Dev->config;
 
-    LOG_INF("Init driver");
+    LOG_DBG("Start to initialize APDS9306...");
 
-	return ret;
+	if(device_is_ready(Config->i2c.bus) == false)
+    {
+		LOG_ERR("Bus device is not ready");
+		return -EINVAL;
+	}
+
+	if(apds9306_sensor_setup(p_Dev) < 0)
+    {
+		LOG_ERR("Failed to setup device!");
+		return -EIO;
+	}
+
+	if(apds9306_interrupt_setup(p_Dev) < 0)
+    {
+		LOG_ERR("Failed to setup interrupts!");
+		return -EIO;
+	}
+
+    LOG_DBG("APDS9306 initialization successful!");
+
+	return 0;
 }
 
 #ifdef CONFIG_PM_DEVICE
@@ -118,9 +420,9 @@ static int apds9306_init(const struct device* p_Dev)
 #endif
 
 #define APDS9306_INIT(inst)							                    \
-	static struct apds9306_data_t apds9306_data_##inst;				    \
+	static struct apds9306_data apds9306_data_##inst;				    \
 									                                    \
-	static const struct apds9306_config_t apds9306_config_##inst = {    \
+	static const struct apds9306_config apds9306_config_##inst = {      \
 		.i2c = I2C_DT_SPEC_INST_GET(inst),				                \
 	};								                                    \
 									                                    \

--- a/app/drivers/sensor/apds9306/apds9306.c
+++ b/app/drivers/sensor/apds9306/apds9306.c
@@ -1,0 +1,136 @@
+/* apds9306.c - Driver for Avago APDS-9306 light sensor. */
+
+/*
+ * Copyright (c) 2023, Daniel Kampert
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT avago_apds9306
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/logging/log.h>
+
+//LOG_MODULE_REGISTER(apds9306, CONFIG_SENSOR_LOG_LEVEL);
+LOG_MODULE_REGISTER(apds9306, LOG_LEVEL_INF);
+
+#if(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 0)
+    #warning "apds9306 driver enabled without any devices"
+#endif
+
+struct apds9306_data_t {
+	int16_t light;
+};
+
+struct apds9306_config_t {
+	struct i2c_dt_spec i2c;
+};								
+
+static int apds9306_sample_fetch(const struct device* p_Dev, enum sensor_channel Channel)
+{
+	struct apds9306_data *data = p_Dev->data;
+	const struct apds9306_config_t *cfg = p_Dev->config;
+	enum pm_device_state pm_state;
+	int ret;
+
+	(void)pm_device_state_get(p_Dev, &pm_state);
+	if(pm_state != PM_DEVICE_STATE_ACTIVE)
+    {
+		ret = -EIO;
+		return ret;
+	}
+
+	switch(Channel)
+    {
+        case SENSOR_CHAN_ALL:
+        case SENSOR_CHAN_LIGHT:
+        {
+            //ret = lm75_fetch_temp(cfg, data);
+            break;
+        }
+        default:
+        {
+            ret = -ENOTSUP;
+            break;
+        }
+	}
+
+	return ret;
+}
+
+static int apds9306_channel_get(const struct device* p_Dev, enum sensor_channel Channel, struct sensor_value* p_Value)
+{
+	struct apds9306_data *data = p_Dev->data;
+
+	switch(Channel)
+    {
+        case SENSOR_CHAN_LIGHT:
+        {
+            return 0;
+        }
+        default:
+        {
+            return -ENOTSUP;
+        }
+	}
+}
+
+static const struct sensor_driver_api apds9306_driver_api = {
+	.sample_fetch = apds9306_sample_fetch,
+	.channel_get = apds9306_channel_get,
+};
+
+static int apds9306_init(const struct device* p_Dev)
+{
+	int ret = 0;
+
+    LOG_INF("Init driver");
+
+	return ret;
+}
+
+#ifdef CONFIG_PM_DEVICE
+    static int apds9306_pm_action(const struct device* p_Dev, enum pm_device_action Action)
+    {
+        switch(Action)
+        {
+            case PM_DEVICE_ACTION_TURN_ON:
+            case PM_DEVICE_ACTION_RESUME:
+            case PM_DEVICE_ACTION_TURN_OFF:
+            case PM_DEVICE_ACTION_SUSPEND:
+            {
+                break;
+            }
+            default:
+            {
+                return -ENOTSUP;
+            }
+        }
+
+        return 0;
+    }
+#endif
+
+#define APDS9306_INIT(inst)							                    \
+	static struct apds9306_data_t apds9306_data_##inst;				    \
+									                                    \
+	static const struct apds9306_config_t apds9306_config_##inst = {    \
+		.i2c = I2C_DT_SPEC_INST_GET(inst),				                \
+	};								                                    \
+									                                    \
+	PM_DEVICE_DT_INST_DEFINE(inst, apds9306_pm_action);                 \
+									                                    \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, apds9306_init,			        \
+			      PM_DEVICE_DT_INST_GET(inst),			                \
+			      &apds9306_data_##inst,				                \
+			      &apds9306_config_##inst, POST_KERNEL,		            \
+			      CONFIG_SENSOR_INIT_PRIORITY,		                    \
+			      &apds9306_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(APDS9306_INIT)

--- a/app/drivers/sensor/apds9306/apds9306.c
+++ b/app/drivers/sensor/apds9306/apds9306.c
@@ -57,15 +57,15 @@ LOG_MODULE_REGISTER(apds9306, CONFIG_SENSOR_LOG_LEVEL);
 #endif
 
 struct apds9306_data {
-	uint32_t light;
+    uint32_t light;
 };
 
 struct apds9306_config {
-	struct i2c_dt_spec i2c;
+    struct i2c_dt_spec i2c;
     uint8_t Resolution;
     uint8_t Rate;
     uint8_t Gain;
-};								
+};
 
 /** @brief          Enable the ALS measurement.
  *  @param p_Dev    Pointer to sensor device
@@ -73,12 +73,12 @@ struct apds9306_config {
 */
 static int apds9306_enable(const struct device* p_Dev)
 {
-	const struct apds9306_config* Config = p_Dev->config;
+    const struct apds9306_config* Config = p_Dev->config;
 
-	if(i2c_reg_update_byte_dt(&Config->i2c, APDS9306_REGISTER_MAIN_CTRL, ADPS9306_BIT_ALS_EN, ADPS9306_BIT_ALS_EN))
+    if(i2c_reg_update_byte_dt(&Config->i2c, APDS9306_REGISTER_MAIN_CTRL, ADPS9306_BIT_ALS_EN, ADPS9306_BIT_ALS_EN))
     {
-		return -EIO;
-	}
+        return -EIO;
+    }
 
     return 0;
 }
@@ -89,13 +89,13 @@ static int apds9306_enable(const struct device* p_Dev)
 */
 static int apds9306_standby(const struct device* p_Dev)
 {
-	const struct apds9306_config* Config = p_Dev->config;
+    const struct apds9306_config* Config = p_Dev->config;
 
-	if(i2c_reg_update_byte_dt(&Config->i2c, APDS9306_REGISTER_MAIN_CTRL, ADPS9306_BIT_ALS_EN, 0x00))
+    if(i2c_reg_update_byte_dt(&Config->i2c, APDS9306_REGISTER_MAIN_CTRL, ADPS9306_BIT_ALS_EN, 0x00))
     {
-		LOG_ERR("Can not disable ALS!");
-		return -EIO;
-	}
+        LOG_ERR("Can not disable ALS!");
+        return -EIO;
+    }
 
     return 0;
 }
@@ -107,9 +107,9 @@ static int apds9306_standby(const struct device* p_Dev)
 */
 static int apds9306_read_light(const struct device* p_Dev, uint32_t* p_Value)
 {
-	int Error;
-	const struct apds9306_config* Config = p_Dev->config;
-	uint8_t Buffer[3];
+    int Error;
+    const struct apds9306_config* Config = p_Dev->config;
+    uint8_t Buffer[3];
     uint8_t Temp;
     uint8_t Register = APDS9306_REGISTER_ALS_DATA_0;
     uint32_t Now;
@@ -117,8 +117,8 @@ static int apds9306_read_light(const struct device* p_Dev, uint32_t* p_Value)
     LOG_DBG("Start a new measurement...");
     if(apds9306_enable(p_Dev) != 0)
     {
-		LOG_ERR("Can not enable ALS!");
-		return -EIO;
+        LOG_ERR("Can not enable ALS!");
+        return -EIO;
     }
 
     // Wait for the oscillator power up. This needs typically 5 ms, but we wait a bit longer to be sure.
@@ -147,20 +147,20 @@ static int apds9306_read_light(const struct device* p_Dev, uint32_t* p_Value)
 
     if(apds9306_standby(p_Dev) != 0)
     {
-		LOG_ERR("Can not disable ALS!");
-		return -EIO;
+        LOG_ERR("Can not disable ALS!");
+        return -EIO;
     }
 
     // Read the results.
-	Error = i2c_write_read_dt(&Config->i2c, &Register, sizeof(Register), &Buffer, sizeof(Buffer));
-	if(Error < 0)
+    Error = i2c_write_read_dt(&Config->i2c, &Register, sizeof(Register), &Buffer, sizeof(Buffer));
+    if(Error < 0)
     {
-		return Error;
-	}
+        return Error;
+    }
     
     *p_Value = sys_get_le24(Buffer);
 
-	return 0;
+    return 0;
 }
 
 static int apds9306_attr_set(const struct device* p_Dev, enum sensor_channel Channel, enum sensor_attribute Attribute, const struct sensor_value* p_Value)
@@ -168,16 +168,16 @@ static int apds9306_attr_set(const struct device* p_Dev, enum sensor_channel Cha
     uint8_t Mask;
     uint8_t Value;
     uint8_t Register;
-	const struct apds9306_config* Config = p_Dev->config;
+    const struct apds9306_config* Config = p_Dev->config;
 
-	__ASSERT_NO_MSG(p_Value != NULL);
+    __ASSERT_NO_MSG(p_Value != NULL);
 
-	if(Channel != SENSOR_CHAN_LIGHT)
+    if(Channel != SENSOR_CHAN_LIGHT)
     {
-		return -ENOTSUP;
-	}
+        return -ENOTSUP;
+    }
 
-	if(Attribute == SENSOR_ATTR_SAMPLING_FREQUENCY)
+    if(Attribute == SENSOR_ATTR_SAMPLING_FREQUENCY)
     {
         Register = APDS9306_REGISTER_ALS_MEAS_RATE;
         Mask = (0x07) << 0x00;
@@ -200,13 +200,13 @@ static int apds9306_attr_set(const struct device* p_Dev, enum sensor_channel Cha
         return -ENOTSUP;
     }
 
-	if(i2c_reg_update_byte_dt(&Config->i2c, Register, Mask, Value))
+    if(i2c_reg_update_byte_dt(&Config->i2c, Register, Mask, Value))
     {
-		LOG_ERR("Failed to set sensor attribute!");
-		return -EIO;
-	}
+        LOG_ERR("Failed to set sensor attribute!");
+        return -EIO;
+    }
 
-	return 0;
+    return 0;
 }
 
 static int apds9306_attr_get(const struct device* p_Dev, enum sensor_channel Channel, enum sensor_attribute Attribute, struct sensor_value* p_Value)
@@ -214,16 +214,16 @@ static int apds9306_attr_get(const struct device* p_Dev, enum sensor_channel Cha
     uint8_t Mask;
     uint8_t Value;
     uint8_t Register;
-	const struct apds9306_config* Config = p_Dev->config;
+    const struct apds9306_config* Config = p_Dev->config;
 
-	__ASSERT_NO_MSG(p_Value != NULL);
+    __ASSERT_NO_MSG(p_Value != NULL);
 
-	if(Channel != SENSOR_CHAN_LIGHT)
+    if(Channel != SENSOR_CHAN_LIGHT)
     {
-		return -ENOTSUP;
-	}
+        return -ENOTSUP;
+    }
 
-	if(Attribute == SENSOR_ATTR_SAMPLING_FREQUENCY)
+    if(Attribute == SENSOR_ATTR_SAMPLING_FREQUENCY)
     {
         Register = APDS9306_REGISTER_ALS_MEAS_RATE;
         Mask = 0x00;
@@ -243,37 +243,37 @@ static int apds9306_attr_get(const struct device* p_Dev, enum sensor_channel Cha
         return -ENOTSUP;
     }
 
-	if(i2c_reg_read_byte_dt(&Config->i2c, Register, &Value))
+    if(i2c_reg_read_byte_dt(&Config->i2c, Register, &Value))
     {
-		LOG_ERR("Failed to read sensor attribute!");
-		return -EIO;
-	}
+        LOG_ERR("Failed to read sensor attribute!");
+        return -EIO;
+    }
 
     LOG_DBG("Attribute value: %u", Value);
 
     p_Value->val1 = (Value >> Mask) & 0x07;
     p_Value->val2 = 0;
 
-	return 0;
+    return 0;
 }
 
 static int apds9306_sample_fetch(const struct device* p_Dev, enum sensor_channel Channel)
 {
     int Error;
     uint32_t Value;
-	struct apds9306_data* Data = p_Dev->data;
-	enum pm_device_state pm_state;
+    struct apds9306_data* Data = p_Dev->data;
+    enum pm_device_state pm_state;
 
-	(void)pm_device_state_get(p_Dev, &pm_state);
-	if(pm_state != PM_DEVICE_STATE_ACTIVE)
+    (void)pm_device_state_get(p_Dev, &pm_state);
+    if(pm_state != PM_DEVICE_STATE_ACTIVE)
     {
-		return -EIO;
-	}
+        return -EIO;
+    }
 
-	if((Channel != SENSOR_CHAN_ALL) && (Channel != SENSOR_CHAN_LIGHT))
+    if((Channel != SENSOR_CHAN_ALL) && (Channel != SENSOR_CHAN_LIGHT))
     {
-		return -ENOTSUP;
-	}
+        return -ENOTSUP;
+    }
 
     Error = apds9306_read_light(p_Dev, &Value);
     if(Error < 0)
@@ -285,14 +285,14 @@ static int apds9306_sample_fetch(const struct device* p_Dev, enum sensor_channel
 
     LOG_DBG("Sensor value: %u", Data->light);
 
-	return 0;
+    return 0;
 }
 
 static int apds9306_channel_get(const struct device* p_Dev, enum sensor_channel Channel, struct sensor_value* p_Value)
 {
-	struct apds9306_data* Data = p_Dev->data;
+    struct apds9306_data* Data = p_Dev->data;
 
-	switch(Channel)
+    switch(Channel)
     {
         case SENSOR_CHAN_LIGHT:
         {
@@ -305,14 +305,14 @@ static int apds9306_channel_get(const struct device* p_Dev, enum sensor_channel 
         {
             return -ENOTSUP;
         }
-	}
+    }
 }
 
 static int apds9306_sensor_setup(const struct device* p_Dev)
 {
     uint32_t Now;
-	uint8_t Temp;
-	const struct apds9306_config* Config = p_Dev->config;
+    uint8_t Temp;
+    const struct apds9306_config* Config = p_Dev->config;
 
     // Wait for the device to become ready after a power cycle.
     Now = k_uptime_get_32();
@@ -330,71 +330,71 @@ static int apds9306_sensor_setup(const struct device* p_Dev)
         k_msleep(10);
     } while(Temp & APDS9306_BIT_POWER_ON_STATUS);
 
-	if(i2c_reg_read_byte_dt(&Config->i2c, APDS9306_REGISTER_PART_ID, &Temp))
+    if(i2c_reg_read_byte_dt(&Config->i2c, APDS9306_REGISTER_PART_ID, &Temp))
     {
-		LOG_ERR("Failed reading chip id!");
-		return -EIO;
-	}
+        LOG_ERR("Failed reading chip id!");
+        return -EIO;
+    }
 
-	if(Temp != APDS_9306_CHIP_ID)
+    if(Temp != APDS_9306_CHIP_ID)
     {
-		LOG_ERR("Invalid chip id! Found 0x%X, expect 0x%X", Temp, APDS_9306_CHIP_ID);
-		return -EIO;
-	}
+        LOG_ERR("Invalid chip id! Found 0x%X, expect 0x%X", Temp, APDS_9306_CHIP_ID);
+        return -EIO;
+    }
 
-	// Reset the sensor.
-	if(i2c_reg_write_byte_dt(&Config->i2c, APDS9306_REGISTER_MAIN_CTRL, APDS9306_BIT_SW_RESET))
+    // Reset the sensor.
+    if(i2c_reg_write_byte_dt(&Config->i2c, APDS9306_REGISTER_MAIN_CTRL, APDS9306_BIT_SW_RESET))
     {
-		LOG_ERR("Can not reset the sensor!");
-		return -EIO;
-	}
+        LOG_ERR("Can not reset the sensor!");
+        return -EIO;
+    }
 
     k_msleep(10);
 
-	return 0;
+    return 0;
 }
 
 static int apds9306_interrupt_setup(const struct device* p_Dev)
 {
     // TODO
 
-	return 0;
+    return 0;
 }
 
 static const struct sensor_driver_api apds9306_driver_api = {
     .attr_set = apds9306_attr_set,
-	.attr_get = apds9306_attr_get,
-	.sample_fetch = apds9306_sample_fetch,
-	.channel_get = apds9306_channel_get,
+    .attr_get = apds9306_attr_get,
+    .sample_fetch = apds9306_sample_fetch,
+    .channel_get = apds9306_channel_get,
 };
 
 static int apds9306_init(const struct device* p_Dev)
 {
-	const struct apds9306_config* Config = p_Dev->config;
+    const struct apds9306_config* Config = p_Dev->config;
 
     LOG_DBG("Start to initialize APDS9306...");
 
-	if(device_is_ready(Config->i2c.bus) == false)
+    if(device_is_ready(Config->i2c.bus) == false)
     {
-		LOG_ERR("Bus device is not ready");
-		return -EINVAL;
-	}
+        LOG_ERR("Bus device is not ready");
+        return -EINVAL;
+    }
 
-	if(apds9306_sensor_setup(p_Dev) < 0)
+    if(apds9306_sensor_setup(p_Dev) < 0)
     {
-		LOG_ERR("Failed to setup device!");
-		return -EIO;
-	}
+        LOG_ERR("Failed to setup device!");
+        return -EIO;
+    }
 
-	if(apds9306_interrupt_setup(p_Dev) < 0)
+    if(apds9306_interrupt_setup(p_Dev) < 0)
     {
-		LOG_ERR("Failed to setup interrupts!");
-		return -EIO;
-	}
+        LOG_ERR("Failed to setup interrupts!");
+        return -EIO;
+    }
 
     LOG_DBG("APDS9306 initialization successful!");
 
-	return 0;
+    return 0;
 }
 
 #ifdef CONFIG_PM_DEVICE
@@ -420,19 +420,19 @@ static int apds9306_init(const struct device* p_Dev)
 #endif
 
 #define APDS9306_INIT(inst)							                    \
-	static struct apds9306_data apds9306_data_##inst;				    \
-									                                    \
-	static const struct apds9306_config apds9306_config_##inst = {      \
-		.i2c = I2C_DT_SPEC_INST_GET(inst),				                \
-	};								                                    \
-									                                    \
-	PM_DEVICE_DT_INST_DEFINE(inst, apds9306_pm_action);                 \
-									                                    \
-	SENSOR_DEVICE_DT_INST_DEFINE(inst, apds9306_init,			        \
-			      PM_DEVICE_DT_INST_GET(inst),			                \
-			      &apds9306_data_##inst,				                \
-			      &apds9306_config_##inst, POST_KERNEL,		            \
-			      CONFIG_SENSOR_INIT_PRIORITY,		                    \
-			      &apds9306_driver_api);
+    static struct apds9306_data apds9306_data_##inst;				    \
+                                                                        \
+    static const struct apds9306_config apds9306_config_##inst = {      \
+        .i2c = I2C_DT_SPEC_INST_GET(inst),				                \
+    };								                                    \
+                                                                        \
+    PM_DEVICE_DT_INST_DEFINE(inst, apds9306_pm_action);                 \
+                                                                        \
+    SENSOR_DEVICE_DT_INST_DEFINE(inst, apds9306_init,			        \
+                  PM_DEVICE_DT_INST_GET(inst),			                \
+                  &apds9306_data_##inst,				                \
+                  &apds9306_config_##inst, POST_KERNEL,		            \
+                  CONFIG_SENSOR_INIT_PRIORITY,		                    \
+                  &apds9306_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(APDS9306_INIT)

--- a/app/drivers/sensor/apds9306/apds9306.h
+++ b/app/drivers/sensor/apds9306/apds9306.h
@@ -1,0 +1,60 @@
+/* apds9306.c - Driver for Avago APDS9306 light sensor. */
+
+/*
+ * Copyright (c) 2023, Daniel Kampert
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_APDS9306_APDS9960_H_
+#define ZEPHYR_DRIVERS_SENSOR_APDS9306_APDS9960_H_
+
+#include <zephyr/drivers/sensor.h>
+
+#define DT_DRV_COMPAT avago_apds9306
+
+/** @brief Attribute to set the gain range.
+*/
+#define SENSOR_APDS9306_ATTR_GAIN       SENSOR_ATTR_PRIV_START + 1
+
+/** @brief Attribute to set the resolution.
+*/
+#define SENSOR_APDS9306_ATTR_RESOLUTION SENSOR_ATTR_PRIV_START + 2
+
+/** @brief APDS9306 resolution options. 
+*/
+typedef enum
+{
+    APDS9306_RES_20     = 0,        /**< 20 bit resolution. */
+    APDS9306_RES_19,                /**< 19 bit resolution. */
+    APDS9306_RES_18,                /**< 18 bit resolution (default). */
+    APDS9306_RES_17,                /**< 17 bit resolution. */
+    APDS9306_RES_16,                /**< 16 bit resolution. */
+    APDS9306_RES_13,                /**< 13 bit resolution. */
+} APDS9306_Resolution_t;
+
+/** @brief APDS9306 measurement rate options. 
+*/
+typedef enum
+{
+    APDS9306_RATE_25MS  = 0,        /**< 25 ms measurement rate. */
+    APDS9306_RATE_50MS,             /**< 50 ms measurement rate. */
+    APDS9306_RATE_100MS,            /**< 100 ms measurement rate (default). */
+    APDS9306_RATE_200MS,            /**< 200 ms measurement rate. */
+    APDS9306_RATE_500MS,            /**< 500 ms measurement rate. */
+    APDS9306_RATE_1S,               /**< 1 s measurement rate. */
+    APDS9306_RATE_2S,               /**< 2 s measurement rate. */
+} APDS9306_Rate_t;
+
+/** @brief APDS9306 gain range options. 
+*/
+typedef enum
+{
+    APDS9306_GAIN_1     = 0,        /**< Measurement gain x1. */
+    APDS9306_GAIN_3,                /**< Measurement gain x3 (default). */
+    APDS9306_GAIN_6,                /**< Measurement gain x6. */
+    APDS9306_GAIN_9,                /**< Measurement gain x9. */
+    APDS9306_GAIN_18,               /**< Measurement gain x18. */
+} APDS9306_Gain_t;
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_APDS9306_APDS9960_H_*/

--- a/app/src/applications/2048/CMakeLists.txt
+++ b/app/src/applications/2048/CMakeLists.txt
@@ -1,8 +1,10 @@
-FILE(GLOB app_sources *.c)
-target_sources(app PRIVATE ${app_sources})
+if(CONFIG_APPLICATIONS_USE_2048)
+    FILE(GLOB app_sources *.c)
+    target_sources(app PRIVATE ${app_sources})
 
-set(LV_USE_100ASK_2048 "1")
-target_include_directories(app PRIVATE 2048_lib/src/lv_100ask_2048)
-target_sources(app PRIVATE 2048_lib/src/lv_100ask_2048/lv_100ask_2048.c)
-# File contains some build warnings, ignore those.
-set_source_files_properties(2048_lib/src/lv_100ask_2048/lv_100ask_2048.c TARGET_DIRECTORY app PROPERTIES COMPILE_OPTIONS -w)
+    set(LV_USE_100ASK_2048 "1")
+    target_include_directories(app PRIVATE 2048_lib/src/lv_100ask_2048)
+    target_sources(app PRIVATE 2048_lib/src/lv_100ask_2048/lv_100ask_2048.c)
+    # File contains some build warnings, ignore those.
+    set_source_files_properties(2048_lib/src/lv_100ask_2048/lv_100ask_2048.c TARGET_DIRECTORY app PROPERTIES COMPILE_OPTIONS -w)
+endif()

--- a/app/src/applications/accelerometer/CMakeLists.txt
+++ b/app/src/applications/accelerometer/CMakeLists.txt
@@ -1,2 +1,4 @@
-FILE(GLOB app_sources *.c)
-target_sources(app PRIVATE ${app_sources})
+if(CONFIG_APPLICATIONS_USE_ACCELEROMETER)
+    FILE(GLOB app_sources *.c)
+    target_sources(app PRIVATE ${app_sources})
+endif()

--- a/app/src/applications/battery/CMakeLists.txt
+++ b/app/src/applications/battery/CMakeLists.txt
@@ -1,2 +1,4 @@
-FILE(GLOB app_sources *.c)
-target_sources(app PRIVATE ${app_sources})
+if(CONFIG_APPLICATIONS_USE_BATTERY)
+    FILE(GLOB app_sources *.c)
+    target_sources(app PRIVATE ${app_sources})
+endif()

--- a/app/src/applications/compass/CMakeLists.txt
+++ b/app/src/applications/compass/CMakeLists.txt
@@ -1,2 +1,4 @@
-FILE(GLOB app_sources *.c)
-target_sources(app PRIVATE ${app_sources})
+if(CONFIG_APPLICATIONS_USE_COMPASS)
+    FILE(GLOB app_sources *.c)
+    target_sources(app PRIVATE ${app_sources})
+endif()

--- a/app/src/applications/info/CMakeLists.txt
+++ b/app/src/applications/info/CMakeLists.txt
@@ -1,2 +1,4 @@
-FILE(GLOB app_sources *.c)
-target_sources(app PRIVATE ${app_sources})
+if(CONFIG_APPLICATIONS_USE_INFO)
+    FILE(GLOB app_sources *.c)
+    target_sources(app PRIVATE ${app_sources})
+endif()

--- a/app/src/applications/qr_code/CMakeLists.txt
+++ b/app/src/applications/qr_code/CMakeLists.txt
@@ -1,4 +1,4 @@
-if (CONFIG_DEMO_BUILD)
-FILE(GLOB app_sources *.c)
-target_sources(app PRIVATE ${app_sources})
+if(CONFIG_APPLICATIONS_QR_CODE)
+    FILE(GLOB app_sources *.c)
+    target_sources(app PRIVATE ${app_sources})
 endif()

--- a/app/src/applications/x_ray/CMakeLists.txt
+++ b/app/src/applications/x_ray/CMakeLists.txt
@@ -1,4 +1,4 @@
-if (CONFIG_DEMO_BUILD)
-FILE(GLOB app_sources *.c)
-target_sources(app PRIVATE ${app_sources})
+if(CONFIG_APPLICATIONS_X_RAY)
+    FILE(GLOB app_sources *.c)
+    target_sources(app PRIVATE ${app_sources})
 endif()

--- a/app/src/applications/zds/CMakeLists.txt
+++ b/app/src/applications/zds/CMakeLists.txt
@@ -1,2 +1,4 @@
-FILE(GLOB app_sources *.c)
-target_sources(app PRIVATE ${app_sources})
+if(CONFIG_APPLICATIONS_ZDS)
+    FILE(GLOB app_sources *.c)
+    target_sources(app PRIVATE ${app_sources})
+endif()

--- a/app/src/events/accel_event.c
+++ b/app/src/events/accel_event.c
@@ -5,6 +5,10 @@ ZBUS_CHAN_DEFINE(accel_data_chan,
                  struct accel_event,
                  NULL,
                  NULL,
-                 ZBUS_OBSERVERS(watchface_accel_lis, power_manager_accel_lis, zds_app_accel_lis),
+                 #ifdef CONFIG_APPLICATIONS_USE_ACCELEROMETER
+                    ZBUS_OBSERVERS(watchface_accel_lis, power_manager_accel_lis, zds_app_accel_lis),
+                 #else
+                    ZBUS_OBSERVERS(watchface_accel_lis, power_manager_accel_lis),
+                 #endif
                  ZBUS_MSG_INIT()
                 );

--- a/app/src/events/battery_event.c
+++ b/app/src/events/battery_event.c
@@ -5,6 +5,10 @@ ZBUS_CHAN_DEFINE(battery_sample_data_chan,
                  struct battery_sample_event,
                  NULL,
                  NULL,
-                 ZBUS_OBSERVERS(watchface_battery_event, zsw_phone_app_publisher_battery_event, battery_app_battery_event),
+                 #ifdef CONFIG_APPLICATIONS_USE_BATTERY
+                    ZBUS_OBSERVERS(watchface_battery_event, zsw_phone_app_publisher_battery_event, battery_app_battery_event),
+                 #else
+                    ZBUS_OBSERVERS(watchface_battery_event, zsw_phone_app_publisher_battery_event),
+                 #endif
                  ZBUS_MSG_INIT()
                 );

--- a/app/src/zsw_imu.c
+++ b/app/src/zsw_imu.c
@@ -575,6 +575,7 @@ static int8_t configure_axis_remapping(struct bmi2_dev *bmi2_dev)
 {
     int8_t rslt;
     struct bmi2_remap remapped_axis = { 0 };
+    struct bmi2_remap remapped_axis_read = { 0 };
 
     rslt = bmi2_get_remap_axes(&remapped_axis, bmi2_dev);
     bmi2_error_codes_print_result(rslt);
@@ -597,11 +598,11 @@ static int8_t configure_axis_remapping(struct bmi2_dev *bmi2_dev)
     }
 
     if (rslt == BMI2_OK) {
-        rslt = bmi2_get_remap_axes(&remapped_axis, bmi2_dev);
+        rslt = bmi2_get_remap_axes(&remapped_axis_read, bmi2_dev);
         bmi2_error_codes_print_result(rslt);
     }
 
-    if (!((remapped_axis.x == BMI2_NEG_X) && (remapped_axis.y == BMI2_NEG_Y) && (remapped_axis.z == BMI2_Z))) {
+    if (!((remapped_axis.x == remapped_axis_read.x) && (remapped_axis.y == remapped_axis_read.y) && (remapped_axis.z == remapped_axis_read.z))) {
         LOG_ERR("Wrong axis remapping read after setting");
     }
 


### PR DESCRIPTION
Make the apps selectable via Kconfig instead of manipulating the CMakeLists. Enabled by default:

- Game 2048
- Accelerometer
- Battery
- Compass
- Info
- ZDS

Add driver for APDS9306 light sensor.