### PR TITLE
improve iOS notification behavior and also remove notifications

### DIFF
--- a/app/src/ble/ble_ams.c
+++ b/app/src/ble/ble_ams.c
@@ -165,7 +165,7 @@ static void notify_eu_cb(struct bt_ams_client *ams_c,
         if (notif->ent_attr.entity == BT_AMS_ENTITY_ID_PLAYER &&
             attr_val == BT_AMS_PLAYER_ATTRIBUTE_ID_PLAYBACK_INFO) {
 
-            struct ble_data_event evt_music_state;
+            struct ble_data_event evt_music_state = { 0 };
 
             evt_music_state.data.type = BLE_COMM_DATA_TYPE_MUSIC_STATE;
 


### PR DESCRIPTION
1. The source comes as `com.facebook.Messenger` so remove the first 2x dots;
2. Use the right UID
3. Allow to remove notifications
4. Had an uninitiated struct that I think it was sending weather data unintentionally.