### PR TITLE
Move music control to Zbus and remove `#ifdef`

### DIFF
--- a/app/src/ble/ble_ams.c
+++ b/app/src/ble/ble_ams.c
@@ -63,6 +63,7 @@ static void music_control_event_callback(const struct zbus_channel *chan);
 ZBUS_CHAN_DECLARE(ble_comm_data_chan);
 
 ZBUS_CHAN_DECLARE(music_control_data_chan);
+ZBUS_OBS_DECLARE(ios_music_control_lis);
 ZBUS_LISTENER_DEFINE(ios_music_control_lis, music_control_event_callback);
 
 K_WORK_DELAYABLE_DEFINE(ams_gatt_discover_retry, ams_discover_retry_handle);

--- a/app/src/ble/ble_ams.c
+++ b/app/src/ble/ble_ams.c
@@ -29,6 +29,7 @@
 #include "ble/ble_ams.h"
 #include "ble/ble_comm.h"
 #include "events/ble_data_event.h"
+#include "events/music_event.h"
 
 LOG_MODULE_REGISTER(ble_ams, LOG_LEVEL_INF);
 
@@ -57,10 +58,41 @@ static struct bt_conn *current_conn;
 
 static void ble_ams_delayed_write_handle(struct k_work *item);
 static void ams_discover_retry_handle(struct k_work *item);
+static void music_control_event_callback(const struct zbus_channel *chan);
+
+ZBUS_CHAN_DECLARE(ble_comm_data_chan);
+
+ZBUS_CHAN_DECLARE(music_control_data_chan);
+ZBUS_LISTENER_DEFINE(ios_music_control_lis, music_control_event_callback);
 
 K_WORK_DELAYABLE_DEFINE(ams_gatt_discover_retry, ams_discover_retry_handle);
 K_WORK_DELAYABLE_DEFINE(ble_ams_delayed_write, ble_ams_delayed_write_handle);
-ZBUS_CHAN_DECLARE(ble_comm_data_chan);
+
+static void music_control_event_callback(const struct zbus_channel *chan)
+{
+    const struct music_event *event = zbus_chan_const_msg(chan);
+
+    switch (event->control_type) {
+        case MUSIC_CONTROL_UI_PLAY:
+            ble_ams_play_pause();
+            break;
+        case MUSIC_CONTROL_UI_PAUSE:
+            ble_ams_play_pause();
+            break;
+        case MUSIC_CONTROL_UI_NEXT_TRACK:
+            ble_ams_next_track();
+            break;
+        case MUSIC_CONTROL_UI_PREV_TRACK:
+            ble_ams_previous_track();
+            break;
+
+        case MUSIC_CONTROL_UI_CLOSE:
+        default:
+            // Nothing to do
+            break;
+    }
+
+}
 
 static void notify_rc_cb(struct bt_ams_client *ams_c,
                          const uint8_t *data, size_t len)

--- a/app/src/events/music_event.c
+++ b/app/src/events/music_event.c
@@ -1,0 +1,10 @@
+#include "music_event.h"
+#include <zephyr/zbus/zbus.h>
+
+ZBUS_CHAN_DEFINE(music_control_data_chan,
+                 struct music_event,
+                 NULL,
+                 NULL,
+                 ZBUS_OBSERVERS(android_music_control_lis, ios_music_control_lis),
+                 ZBUS_MSG_INIT()
+                );

--- a/app/src/events/music_event.c
+++ b/app/src/events/music_event.c
@@ -5,6 +5,6 @@ ZBUS_CHAN_DEFINE(music_control_data_chan,
                  struct music_event,
                  NULL,
                  NULL,
-                 ZBUS_OBSERVERS(android_music_control_lis, ios_music_control_lis),
+                 ZBUS_OBSERVERS(android_music_control_lis),
                  ZBUS_MSG_INIT()
                 );

--- a/app/src/events/music_event.h
+++ b/app/src/events/music_event.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "music_control/music_control_ui.h"
+
+struct music_event {
+    music_control_ui_evt_type_t control_type;
+};


### PR DESCRIPTION
`ble_comm.c` could be refactored and some of it moved to `ble_gadgetbridge.c` for example, `music_control_event_callback` looks a bit misplaced now, but it should work

https://github.com/jakkra/ZSWatch/issues/112 ?