### PR TITLE
Do not set timezone on iOS and fix Music Control

### DIFF
--- a/app/src/ble/ble_ams.c
+++ b/app/src/ble/ble_ams.c
@@ -64,6 +64,7 @@ ZBUS_CHAN_DECLARE(ble_comm_data_chan);
 
 ZBUS_CHAN_DECLARE(music_control_data_chan);
 ZBUS_OBS_DECLARE(ios_music_control_lis);
+ZBUS_CHAN_ADD_OBS(music_control_data_chan, ios_music_control_lis, 1);
 ZBUS_LISTENER_DEFINE(ios_music_control_lis, music_control_event_callback);
 
 K_WORK_DELAYABLE_DEFINE(ams_gatt_discover_retry, ams_discover_retry_handle);

--- a/app/src/zsw_clock.c
+++ b/app/src/zsw_clock.c
@@ -39,8 +39,10 @@ ZBUS_LISTENER_DEFINE(zsw_clock_lis, zbus_periodic_slow_callback);
 
 void zsw_clock_init(uint64_t start_time_seconds)
 {
+#ifdef CONFIG_BLE_USES_GADGETBRIDGE
     setenv("TZ", "CET-1CEST,M3.5.0,M10.5.0/3", 1);
     tzset();
+#endif
 
     struct timespec tspec;
     tspec.tv_sec = start_time_seconds;


### PR DESCRIPTION
The `ifdef` is ugly but when I get hold of an Android phone will remove and get the Timezone from Gadgetbridge instead, tomorrow?

Also an opsie from before where the zbus observer was not addded.