### PR TITLE
Enter inactive mode by flicking the watch

### DIFF
--- a/app/boards/arm/zswatch_nrf5340/zswatch_nrf5340_cpuapp_3.overlay
+++ b/app/boards/arm/zswatch_nrf5340/zswatch_nrf5340_cpuapp_3.overlay
@@ -90,7 +90,10 @@
         reg = <0x68>;
         status = "okay";
         int-gpios = <&gpio0 14 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
+        // NOTE: The swap is performed AFTER the axis inversion. So we have to invert the y axis of the sensor
+        // to get the x axis of the watch coordinate system.
         swap-xy;
+        invert-y;
     };
 
     apds9306: apds9306@52 {

--- a/app/drivers/sensor/bmi270/bosch_bmi270.c
+++ b/app/drivers/sensor/bmi270/bosch_bmi270.c
@@ -75,10 +75,10 @@ static void bmi2_delay_us(uint32_t period, void *p_intf)
     k_usleep(period);
 }
 
-/** @brief  
- *  @param p_val    
- *  @param raw_val  
- *  @param range    
+/** @brief
+ *  @param p_val
+ *  @param raw_val
+ *  @param range
 */
 static void bmi2_raw2accel_convert(struct sensor_value *p_val, int64_t raw_val, uint8_t range)
 {
@@ -88,10 +88,10 @@ static void bmi2_raw2accel_convert(struct sensor_value *p_val, int64_t raw_val, 
     p_val->val2 = raw_val % 1000000LL;
 }
 
-/** @brief  
- *  @param p_val    
- *  @param raw_val  
- *  @param range    
+/** @brief
+ *  @param p_val
+ *  @param raw_val
+ *  @param range
 */
 static void bmi2_raw2gyro_convert(struct sensor_value *p_val, int64_t raw_val, uint16_t range)
 {
@@ -99,8 +99,8 @@ static void bmi2_raw2gyro_convert(struct sensor_value *p_val, int64_t raw_val, u
     p_val->val2 = ((raw_val * ((int64_t)range) * SENSOR_PI) / (180LL * INT16_MAX)) % 1000000LL;
 }
 
-/** @brief          
- *  @param p_dev    
+/** @brief
+ *  @param p_dev
  *  @return         0 when successful
 */
 static int bmi2_configure_axis_remapping(const struct device *p_dev)
@@ -114,7 +114,7 @@ static int bmi2_configure_axis_remapping(const struct device *p_dev)
         return -EFAULT;
     }
 
-    // Initialize 
+    // Initialize
     // x -> x
     // y -> y
     // z -> z
@@ -162,15 +162,15 @@ static int bmi2_configure_axis_remapping(const struct device *p_dev)
     return 0;
 }
 
-/** @brief              
- *  @param p_dev        
- *  @param channel      
- *  @param attribute    
- *  @param p_value      
+/** @brief
+ *  @param p_dev
+ *  @param channel
+ *  @param attribute
+ *  @param p_value
  *  @return             0 when successful
 */
 static int bmi270_attr_set(const struct device *p_dev, enum sensor_channel channel, enum sensor_attribute attribute,
-                             const struct sensor_value *p_value)
+                           const struct sensor_value *p_value)
 {
     __ASSERT_NO_MSG(p_value != NULL);
 
@@ -187,14 +187,14 @@ static int bmi270_attr_set(const struct device *p_dev, enum sensor_channel chann
                 return bmi2_set_accel_osr(p_dev, p_value);
             case SENSOR_ATTR_FULL_SCALE:
                 return bmi2_set_accel_range(p_dev, p_value);
-    /*
-    #if CONFIG_BMI270_PLUS_TRIGGER
-            case SENSOR_ATTR_SLOPE_DUR:
-                return bmi270_write_anymo_duration(p_dev, p_value->val1);
-            case SENSOR_ATTR_SLOPE_TH:
-                return bmi270_write_anymo_threshold(p_dev, *p_value);
-    #endif
-    */
+            /*
+            #if CONFIG_BMI270_PLUS_TRIGGER
+                    case SENSOR_ATTR_SLOPE_DUR:
+                        return bmi270_write_anymo_duration(p_dev, p_value->val1);
+                    case SENSOR_ATTR_SLOPE_TH:
+                        return bmi270_write_anymo_threshold(p_dev, *p_value);
+            #endif
+            */
             default:
                 return -ENOTSUP;
         }
@@ -238,8 +238,7 @@ static int bmi270_attr_set(const struct device *p_dev, enum sensor_channel chann
                     if (bmi2_disable_feature(p_dev, p_value->val1 & 0xFF) != BMI2_OK) {
                         return -EFAULT;
                     }
-                }
-                else if ((p_value->val2 & 0x01) == 1) {
+                } else if ((p_value->val2 & 0x01) == 1) {
                     if (bmi2_enable_feature(p_dev, p_value->val1, (p_value->val2 >> 1) & 0x01) != BMI2_OK) {
                         return -EFAULT;
                     }
@@ -247,14 +246,17 @@ static int bmi270_attr_set(const struct device *p_dev, enum sensor_channel chann
             default:
                 return -ENOTSUP;
         }
+    } else if (channel == SENSOR_CHAN_CONFIG) {
+        // TODO: Implement this
+        return -ENOTSUP;
     }
 
     return -ENOTSUP;
 }
 
-/** @brief          
- *  @param p_dev    
- *  @param channel  
+/** @brief
+ *  @param p_dev
+ *  @param channel
  *  @return         0 when successful
 */
 static int bmi270_sample_fetch(const struct device *p_dev, enum sensor_channel channel)
@@ -303,10 +305,10 @@ static int bmi270_sample_fetch(const struct device *p_dev, enum sensor_channel c
     return 0;
 }
 
-/** @brief          
- *  @param p_dev    
- *  @param channel  
- *  @param p_value  
+/** @brief
+ *  @param p_dev
+ *  @param channel
+ *  @param p_value
  *  @return         0 when successful
 */
 static int bmi270_channel_get(const struct device *p_dev, enum sensor_channel channel, struct sensor_value *p_value)
@@ -338,8 +340,7 @@ static int bmi270_channel_get(const struct device *p_dev, enum sensor_channel ch
     } else if (channel == SENSOR_CHAN_AMBIENT_TEMP) {
         float temperature = (((float)((int16_t)data->temp)) / 512.0) + 23.0;
         sensor_value_from_float(p_value, temperature);
-    }
-    else if (channel == SENSOR_CHAN_STEPS) {
+    } else if (channel == SENSOR_CHAN_STEPS) {
         struct bmi2_feat_sensor_data sensor_data;
 
         sensor_data.type = BMI2_STEP_COUNTER;
@@ -368,7 +369,7 @@ static int bmi270_channel_get(const struct device *p_dev, enum sensor_channel ch
         p_value->val1 = sensor_data.sens_data.wrist_gesture_output;
     } else {
         return -ENOTSUP;
-    } 
+    }
 
     return 0;
 }
@@ -382,8 +383,8 @@ static const struct sensor_driver_api bmi270_driver_api = {
 #endif
 };
 
-/** @brief          
- *  @param p_dev    
+/** @brief
+ *  @param p_dev
  *  @return         0 when successful
 */
 static int bmi270_sensor_init(const struct device *p_dev)
@@ -448,9 +449,9 @@ static int bmi270_sensor_init(const struct device *p_dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-/** @brief          
- *  @param p_dev    
- *  @param action   
+/** @brief
+ *  @param p_dev
+ *  @param action
  *  @return         0 when successful
 */
 static int bmi270_pm_action(const struct device *p_dev, enum pm_device_action action)
@@ -490,7 +491,7 @@ static int bmi270_pm_action(const struct device *p_dev, enum pm_device_action ac
         .invert_x = DT_INST_PROP(inst, invert_x),                                   \
         .invert_y = DT_INST_PROP(inst, invert_y),                                   \
         IF_ENABLED(CONFIG_BMI270_PLUS_TRIGGER,                                      \
-            (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, { 0 }),))	    \
+            (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, { 0 }),))        \
     };                                                                              \
                                                                                     \
     PM_DEVICE_DT_INST_DEFINE(inst, bmi270_pm_action);                               \

--- a/app/drivers/sensor/bmi270/bosch_bmi270.h
+++ b/app/drivers/sensor/bmi270/bosch_bmi270.h
@@ -24,6 +24,10 @@
 */
 #define SENSOR_CHAN_FEATURE             (SENSOR_CHAN_PRIV_START + 4)
 
+/** @brief Device configuration channel.
+*/
+#define SENSOR_CHAN_CONFIG              (SENSOR_CHAN_PRIV_START + 5)
+
 /** @brief Wrist gesture detection like flick in/out, push arm down(pivot up, wrist jiggle/shake).
 */
 #define SENSOR_TRIG_WRIST_GESTURE       (SENSOR_TRIG_PRIV_START + 1)
@@ -89,6 +93,30 @@
 /** @brief
 */
 #define BOSCH_BMI270_FEAT_WEAR_WAKE_UP  20
+
+/** @brief Unknown gesture value from trigger event.
+*/
+#define BOSCH_BMI270_GESTURE_UNKNOWN    0
+
+/** @brief Arm down gesture value from trigger event.
+*/
+#define BOSCH_BMI270_GESTURE_ARM_DOWN   1
+
+/** @brief Pivot up gesture value from trigger event.
+*/
+#define BOSCH_BMI270_GESTURE_PIVOT_UP   2
+
+/** @brief Wrist shake jiggle gesture value from trigger event.
+*/
+#define BOSCH_BMI270_GESTURE_JIGGLE     3
+
+/** @brief FLick in gesture value from trigger event.
+*/
+#define BOSCH_BMI270_GESTURE_FLICK_IN   4
+
+/** @brief Flick out gesture value from trigger event.
+*/
+#define BOSCH_BMI270_GESTURE_FLICK_OUT  5
 
 #define BOSCH_BMI270_ACC_ODR_25D32_HZ   0x01
 #define BOSCH_BMI270_ACC_ODR_25D16_HZ   0x02

--- a/app/drivers/sensor/bmi270/private/bosch_bmi270_config.c
+++ b/app/drivers/sensor/bmi270/private/bosch_bmi270_config.c
@@ -43,8 +43,8 @@ static bosch_bmi270_feature_config_set_t bmi270_enabled_features[] = {
     { .sensor_id = BMI2_NO_MOTION, .cfg_func = bmi2_configure_no_motion},
 };
 
-/** @brief              
- *  @param sensor_id       
+/** @brief
+ *  @param sensor_id
  *  @return             true when feature available
 */
 static bool bmi2_is_sensor_feature(uint8_t sensor_id)
@@ -125,9 +125,9 @@ int8_t bmi2_configure_enable_all(const struct device *p_dev, struct bmi270_data 
     return 0;
 }
 
-/** @brief          
- *  @param p_config 
- *  @param p_data   
+/** @brief
+ *  @param p_config
+ *  @param p_data
 */
 static void bmi2_configure_accel(struct bmi2_sens_config *p_config, struct bmi270_data *p_data)
 {
@@ -156,7 +156,7 @@ static void bmi2_configure_accel(struct bmi2_sens_config *p_config, struct bmi27
         */
     p_config->cfg.acc.filter_perf = BMI2_POWER_OPT_MODE;
 
-    switch(p_config->cfg.acc.range) {
+    switch (p_config->cfg.acc.range) {
         case BMI2_ACC_RANGE_2G:
             p_data->acc_range = 2;
             break;
@@ -174,9 +174,9 @@ static void bmi2_configure_accel(struct bmi2_sens_config *p_config, struct bmi27
     p_data->acc_odr = p_config->cfg.acc.odr;
 }
 
-/** @brief          
- *  @param p_config 
- *  @param p_data   
+/** @brief
+ *  @param p_config
+ *  @param p_data
 */
 static void bmi2_configure_gyro(struct bmi2_sens_config *p_config, struct bmi270_data *p_data)
 {
@@ -205,7 +205,7 @@ static void bmi2_configure_gyro(struct bmi2_sens_config *p_config, struct bmi270
         */
     p_config->cfg.gyr.filter_perf = BMI2_POWER_OPT_MODE;
 
-    switch(p_config->cfg.gyr.range) {
+    switch (p_config->cfg.gyr.range) {
         case BMI2_GYR_RANGE_2000:
             p_data->gyr_range = 2000;
             break;
@@ -226,18 +226,18 @@ static void bmi2_configure_gyro(struct bmi2_sens_config *p_config, struct bmi270
     p_data->gyr_odr = p_config->cfg.gyr.odr;
 }
 
-/** @brief          
- *  @param p_config 
- *  @param p_data   
+/** @brief
+ *  @param p_config
+ *  @param p_data
 */
 static void bmi2_configure_step_counter(struct bmi2_sens_config *p_config, struct bmi270_data *p_data)
 {
     p_config->cfg.step_counter.watermark_level = 1;
 }
 
-/** @brief          
- *  @param p_config 
- *  @param p_data   
+/** @brief
+ *  @param p_config
+ *  @param p_data
 */
 static void bmi2_configure_anymotion(struct bmi2_sens_config *p_config, struct bmi270_data *p_data)
 {
@@ -248,18 +248,18 @@ static void bmi2_configure_anymotion(struct bmi2_sens_config *p_config, struct b
     p_config->cfg.any_motion.threshold = 0x68;
 }
 
-/** @brief          
- *  @param p_config 
- *  @param p_data   
+/** @brief
+ *  @param p_config
+ *  @param p_data
 */
 static void bmi2_configure_gesture_detect(struct bmi2_sens_config *p_config, struct bmi270_data *p_data)
 {
     p_config->cfg.wrist_gest.wearable_arm = BMI2_ARM_LEFT;
 }
 
-/** @brief          
- *  @param p_config 
- *  @param p_data   
+/** @brief
+ *  @param p_config
+ *  @param p_data
 */
 static void bmi2_configure_wrist_wakeup(struct bmi2_sens_config *p_config, struct bmi270_data *p_data)
 {
@@ -267,9 +267,9 @@ static void bmi2_configure_wrist_wakeup(struct bmi2_sens_config *p_config, struc
     // TODO many things to bmi2_configure here
 }
 
-/** @brief          
- *  @param p_config 
- *  @param p_data   
+/** @brief
+ *  @param p_config
+ *  @param p_data
 */
 static void bmi2_configure_no_motion(struct bmi2_sens_config *p_config, struct bmi270_data *p_data)
 {
@@ -296,24 +296,24 @@ int bmi2_set_accel_range(const struct device *p_dev, const struct sensor_value *
     config &= ~0x03;
 
     switch (p_range->val1) {
-    case BOSCH_BMI270_ACC_RANGE_2G:
-        config |= BOSCH_BMI270_ACC_RANGE_2G;
-        data->acc_range = 2;
-        break;
-    case BOSCH_BMI270_ACC_RANGE_4G:
-        config |= BOSCH_BMI270_ACC_RANGE_4G;
-        data->acc_range = 4;
-        break;
-    case BOSCH_BMI270_ACC_RANGE_8G:
-        config |= BOSCH_BMI270_ACC_RANGE_8G;
-        data->acc_range = 8;
-        break;
-    case BOSCH_BMI270_ACC_RANGE_16G:
-        config |= BOSCH_BMI270_ACC_RANGE_16G;
-        data->acc_range = 16;
-        break;
-    default:
-        return -ENOTSUP;
+        case BOSCH_BMI270_ACC_RANGE_2G:
+            config |= BOSCH_BMI270_ACC_RANGE_2G;
+            data->acc_range = 2;
+            break;
+        case BOSCH_BMI270_ACC_RANGE_4G:
+            config |= BOSCH_BMI270_ACC_RANGE_4G;
+            data->acc_range = 4;
+            break;
+        case BOSCH_BMI270_ACC_RANGE_8G:
+            config |= BOSCH_BMI270_ACC_RANGE_8G;
+            data->acc_range = 8;
+            break;
+        case BOSCH_BMI270_ACC_RANGE_16G:
+            config |= BOSCH_BMI270_ACC_RANGE_16G;
+            data->acc_range = 16;
+            break;
+        default:
+            return -ENOTSUP;
     }
 
     if (data->bmi2.write(BOSCH_BMI270_REG_ACC_RANGE, &config, 1, data->bmi2.intf_ptr) != BMI2_OK) {
@@ -352,7 +352,7 @@ int bmi2_set_accel_odr(const struct device *p_dev, const struct sensor_value *p_
 
     // If the Sampling frequency is higher than 100Hz, enter performance mode else, power optimized.
     if (p_odr->val1 >= BOSCH_BMI270_ACC_ODR_100_HZ) {
-        config |= (0x01 << 0x07);     
+        config |= (0x01 << 0x07);
     } else {
         config &= ~(0x01 << 0x07);
     }
@@ -397,49 +397,49 @@ int bmi2_set_accel_osr(const struct device *p_dev, const struct sensor_value *p_
         LOG_DBG("Performance mode active");
 
         switch (p_osr->val1) {
-        case BOSCH_BMI270_ACC_OSR4:
-            config |= (0x00 << 0x04);
-            break;
-        case BOSCH_BMI270_ACC_OSR2:
-            config |= (0x01 << 0x04);
-            break;
-        case BOSCH_BMI270_ACC_OSR1:
-            config |= (0x02 << 0x04);
-            break;
-        default:
-            config |= (0x03 << 0x04);
-            break;
+            case BOSCH_BMI270_ACC_OSR4:
+                config |= (0x00 << 0x04);
+                break;
+            case BOSCH_BMI270_ACC_OSR2:
+                config |= (0x01 << 0x04);
+                break;
+            case BOSCH_BMI270_ACC_OSR1:
+                config |= (0x02 << 0x04);
+                break;
+            default:
+                config |= (0x03 << 0x04);
+                break;
         }
     } else {
         LOG_DBG("Low-Power mode active");
 
         switch (p_osr->val1) {
-        case BOSCH_BMI270_AVG1:
-            config |= (0x00 << 0x04);
-            break;
-        case BOSCH_BMI270_AVG2:
-            config |= (0x01 << 0x04);
-            break;
-        case BOSCH_BMI270_AVG4:
-            config |= (0x02 << 0x04);
-            break;
-        case BOSCH_BMI270_AVG8:
-            config |= (0x03 << 0x04);
-            break;
-        case BOSCH_BMI270_AVG16:
-            config |= (0x04 << 0x04);
-            break;
-        case BOSCH_BMI270_AVG32:
-            config |= (0x05 << 0x04);
-            break;
-        case BOSCH_BMI270_AVG64:
-            config |= (0x06 << 0x04);
-            break;
-        case BOSCH_BMI270_AVG128:
-            config |= (0x07 << 0x04);
-            break;
-        default:
-            return -ENOTSUP;
+            case BOSCH_BMI270_AVG1:
+                config |= (0x00 << 0x04);
+                break;
+            case BOSCH_BMI270_AVG2:
+                config |= (0x01 << 0x04);
+                break;
+            case BOSCH_BMI270_AVG4:
+                config |= (0x02 << 0x04);
+                break;
+            case BOSCH_BMI270_AVG8:
+                config |= (0x03 << 0x04);
+                break;
+            case BOSCH_BMI270_AVG16:
+                config |= (0x04 << 0x04);
+                break;
+            case BOSCH_BMI270_AVG32:
+                config |= (0x05 << 0x04);
+                break;
+            case BOSCH_BMI270_AVG64:
+                config |= (0x06 << 0x04);
+                break;
+            case BOSCH_BMI270_AVG128:
+                config |= (0x07 << 0x04);
+                break;
+            default:
+                return -ENOTSUP;
         }
     }
 
@@ -478,28 +478,28 @@ int bmi2_set_gyro_range(const struct device *p_dev, const struct sensor_value *p
     config &= ~0x07;
 
     switch (p_range->val1) {
-    case BOSCH_BMI270_GYR_RANGE_2000:
-        config |= BOSCH_BMI270_GYR_RANGE_2000;
-        data->gyr_range = 2000;
-        break;
-    case BOSCH_BMI270_GYR_RANGE_1000:
-        config |= BOSCH_BMI270_GYR_RANGE_1000;
-        data->gyr_range = 1000;
-        break;
-    case BOSCH_BMI270_GYR_RANGE_500:
-        config |= BOSCH_BMI270_GYR_RANGE_500;
-        data->gyr_range = 500;
-        break;
-    case BOSCH_BMI270_GYR_RANGE_250:
-        config |= BOSCH_BMI270_GYR_RANGE_250;
-        data->gyr_range = 250;
-        break;
-    case BOSCH_BMI270_GYR_RANGE_125:
-        config |= BOSCH_BMI270_GYR_RANGE_125;
-        data->gyr_range = 125;
-        break;
-    default:
-        return -ENOTSUP;
+        case BOSCH_BMI270_GYR_RANGE_2000:
+            config |= BOSCH_BMI270_GYR_RANGE_2000;
+            data->gyr_range = 2000;
+            break;
+        case BOSCH_BMI270_GYR_RANGE_1000:
+            config |= BOSCH_BMI270_GYR_RANGE_1000;
+            data->gyr_range = 1000;
+            break;
+        case BOSCH_BMI270_GYR_RANGE_500:
+            config |= BOSCH_BMI270_GYR_RANGE_500;
+            data->gyr_range = 500;
+            break;
+        case BOSCH_BMI270_GYR_RANGE_250:
+            config |= BOSCH_BMI270_GYR_RANGE_250;
+            data->gyr_range = 250;
+            break;
+        case BOSCH_BMI270_GYR_RANGE_125:
+            config |= BOSCH_BMI270_GYR_RANGE_125;
+            data->gyr_range = 125;
+            break;
+        default:
+            return -ENOTSUP;
     }
 
     if (data->bmi2.write(BOSCH_BMI270_REG_GYR_RANGE, &config, 1, data->bmi2.intf_ptr) != BMI2_OK) {

--- a/app/dts/bindings/sensor/bosch,bmi270-plus.yml
+++ b/app/dts/bindings/sensor/bosch,bmi270-plus.yml
@@ -19,9 +19,9 @@ properties:
     invert-x:
       type: boolean
       description: |
-        Invert x axis.
+        Invert the x axis.
 
     invert-y:
       type: boolean
       description: |
-        Invert y axis.
+        Invert the y axis.

--- a/app/src/managers/zsw_power_manager.h
+++ b/app/src/managers/zsw_power_manager.h
@@ -14,34 +14,30 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef __ZSW_POWER_MANAGER_H_
-#define __ZSW_POWER_MANAGER_H_
+
+# pragma once
+
 #include <stdbool.h>
 #include <stdint.h>
 
-typedef enum zsw_power_manager_state_t {
+typedef enum {
     ZSW_ACTIVITY_STATE_ACTIVE,
     ZSW_ACTIVITY_STATE_INACTIVE,
     ZSW_ACTIVITY_STATE_NOT_WORN_STATIONARY,
 } zsw_power_manager_state_t;
 
-/*
-*   Resets the inactivity timeout that will make the watch go
-*   into inactive mode with display etc. turned off to save power.
-*
-*   Return true if the call caused wakup from inactive state, false otherwise.
+/** @brief  Resets the inactivity timeout that will make the watch go
+*           into inactive mode with display etc. turned off to save power.
+ *  @return true if the call caused wakup from inactive state, false otherwise.
 */
 bool zsw_power_manager_reset_idle_timout(void);
 
-/*
-*   Returns the time in seconds until the watch will go into inactive state.
+/** @brief  Returns the time in seconds until the watch will go into inactive state.
+ *  @return Time until the watch will go into inactive state
 */
 uint32_t zsw_power_manager_get_ms_to_inactive(void);
 
-/*
-*   Returns the current power manager state, see @zsw_power_manager_state_t
+/** @brief  Returns the current power manager state, see @zsw_power_manager_state_t.
+ *  @return Power manager state
 */
 zsw_power_manager_state_t zsw_power_manager_get_state(void);
-
-#endif // __ZSW_POWER_MANAGER_H_
-

--- a/app/src/sensors/zsw_imu.c
+++ b/app/src/sensors/zsw_imu.c
@@ -56,8 +56,7 @@ static void bmi270_trigger_handler(const struct device *dev, const struct sensor
         case SENSOR_TRIG_STEP: {
             struct sensor_value sensor_val;
 
-            if ((sensor_sample_fetch_chan(bmi270, SENSOR_CHAN_STEPS) == 0) &&
-                (sensor_channel_get(bmi270, SENSOR_CHAN_STEPS, &sensor_val) == 0)) {
+            if (sensor_channel_get(bmi270, SENSOR_CHAN_STEPS, &sensor_val) == 0) {
 
                 evt.type = ZSW_IMU_EVT_TYPE_STEP;
                 evt.data.step.count = sensor_val.val1;
@@ -70,8 +69,7 @@ static void bmi270_trigger_handler(const struct device *dev, const struct sensor
         case SENSOR_TRIG_ACTIVITY: {
             struct sensor_value sensor_val;
 
-            if ((sensor_sample_fetch_chan(bmi270, SENSOR_CHAN_ACTIVITY) == 0) &&
-                (sensor_channel_get(bmi270, SENSOR_CHAN_ACTIVITY, &sensor_val) == 0)) {
+            if (sensor_channel_get(bmi270, SENSOR_CHAN_ACTIVITY, &sensor_val) == 0) {
 
                 evt.type = ZSW_IMU_EVT_TYPE_STEP_ACTIVITY;
                 evt.data.step_activity = sensor_val.val1;
@@ -90,8 +88,7 @@ static void bmi270_trigger_handler(const struct device *dev, const struct sensor
         case SENSOR_TRIG_WRIST_GESTURE: {
             struct sensor_value sensor_val;
 
-            if ((sensor_sample_fetch_chan(bmi270, SENSOR_CHAN_GESTURE) == 0) &&
-                (sensor_channel_get(bmi270, SENSOR_CHAN_GESTURE, &sensor_val) == 0)) {
+            if (sensor_channel_get(bmi270, SENSOR_CHAN_GESTURE, &sensor_val) == 0) {
 
                 evt.type = ZSW_IMU_EVT_TYPE_GESTURE;
                 evt.data.gesture = sensor_val.val1;


### PR DESCRIPTION
IMU:
- IMU gestures don´t need a BMI270 "fetch" call

Power manager:
- Add IMU flick in and flick out event to enter inactive mode