### PR TITLE
do not refresh watchface if only one is selected

### DIFF
--- a/app/src/applications/watchface/watchface_app.c
+++ b/app/src/applications/watchface/watchface_app.c
@@ -155,6 +155,10 @@ void watchface_app_stop(void)
 
 void watchface_change(void)
 {
+    if (num_watchfaces == 1) {
+        return;
+    }
+
     watchfaces[current_watchface]->remove();
     current_watchface = (current_watchface + 1) % num_watchfaces;
 


### PR DESCRIPTION
this one line fix prevent the watchface app to refresh/glitch when only one watchface is selected