### PR TITLE
Add reset for step counter + smaller cleanups

### DIFF
--- a/app/boards/arm/zswatch_nrf5340/zswatch_nrf5340_common.dts
+++ b/app/boards/arm/zswatch_nrf5340/zswatch_nrf5340_common.dts
@@ -18,14 +18,6 @@
         zephyr,display = &gc9a01;
     };
 
-    vbatt {
-        compatible = "voltage-divider";
-        io-channels = <&adc 7>;
-        output-ohms = <220000>;
-        full-ohms = <(1500000 + 220000)>;
-        power-gpios = <&gpio1 10 0>;
-    };
-
     pwmleds {
         compatible = "pwm-leds";
         display_blk: pwm_led_0 {
@@ -43,6 +35,11 @@
         invert-x;
     };
 
+    rtc: rtc {
+        status = "okay";
+        compatible = "zephyr,rtc-emul";
+    };
+
     aliases {
         display-blk = &display_blk;
         vibrator-pwm = &vibrator_pwm;
@@ -50,10 +47,6 @@
         sw2 = &button2;
         sw3 = &button3;
         sw4 = &button4;
-        sw-top-right = &button1;
-        sw-top-left = &button4;
-        sw-bottom-right = &button3;
-        sw-bottom-left = &button2;
         watchdog0 = &wdt0;
         mcuboot-button1 = &button1;
     };
@@ -120,7 +113,6 @@
         status = "okay";
         int-gpios = <&gpio0 25 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
     };
-
 };
 
 &i2c2 {
@@ -201,7 +193,6 @@ zephyr_udc0: &usbd {
 };
 
 / {
-
     reserved-memory {
         #address-cells = <1>;
         #size-cells = <1>;

--- a/app/boards/arm/zswatch_nrf5340/zswatch_nrf5340_cpuapp_1.overlay
+++ b/app/boards/arm/zswatch_nrf5340/zswatch_nrf5340_cpuapp_1.overlay
@@ -1,4 +1,12 @@
 / {
+    vbatt {
+        compatible = "voltage-divider";
+        io-channels = <&adc 7>;
+        output-ohms = <220000>;
+        full-ohms = <(1500000 + 220000)>;
+        power-gpios = <&gpio1 10 0>;
+    };
+
     longpress: longpress {
         input = <&buttons>;
         compatible = "zephyr,input-longpress";

--- a/app/boards/arm/zswatch_nrf5340/zswatch_nrf5340_cpuapp_2.overlay
+++ b/app/boards/arm/zswatch_nrf5340/zswatch_nrf5340_cpuapp_2.overlay
@@ -3,6 +3,14 @@
 		nordic,pm-ext-flash = &at25sl128a;
 	};
 
+    vbatt {
+        compatible = "voltage-divider";
+        io-channels = <&adc 7>;
+        output-ohms = <220000>;
+        full-ohms = <(1500000 + 220000)>;
+        power-gpios = <&gpio1 10 0>;
+    };
+
     longpress: longpress {
         input = <&buttons>;
         compatible = "zephyr,input-longpress";

--- a/app/boards/arm/zswatch_nrf5340/zswatch_nrf5340_cpuapp_3.overlay
+++ b/app/boards/arm/zswatch_nrf5340/zswatch_nrf5340_cpuapp_3.overlay
@@ -27,6 +27,14 @@
 		spi-flash0 = &at25sl128a;
 	};
 
+    vbatt {
+        compatible = "voltage-divider";
+        io-channels = <&adc 7>;
+        output-ohms = <220000>;
+        full-ohms = <(1500000 + 220000)>;
+        power-gpios = <&gpio1 10 0>;
+    };
+
     longpress: longpress {
         input = <&buttons>;
         compatible = "zephyr,input-longpress";
@@ -73,7 +81,6 @@
         regulator-name = "vib-pwr-ctrl";
         enable-gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
     };
-
 };
 
 &i2c1 {

--- a/app/boards/arm/zswatch_nrf5340/zswatch_nrf5340_cpuapp_4.overlay
+++ b/app/boards/arm/zswatch_nrf5340/zswatch_nrf5340_cpuapp_4.overlay
@@ -70,6 +70,14 @@
 		spi-flash0 = &at25sl128a;
 	};
 
+    vbatt {
+        compatible = "voltage-divider";
+        io-channels = <&adc 7>;
+        output-ohms = <220000>;
+        full-ohms = <(1500000 + 220000)>;
+        power-gpios = <&gpio1 10 0>;
+    };
+
     longpress: longpress {
         input = <&buttons>;
         compatible = "zephyr,input-longpress";

--- a/app/boards/no_touch.overlay
+++ b/app/boards/no_touch.overlay
@@ -22,5 +22,4 @@
         reset-gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
         dc-gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>;
     };
-
 };

--- a/app/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/app/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -70,10 +70,6 @@
     };
 
     aliases {
-        sw-top-right = &button3;
-        sw-top-left = &button2;
-        sw-bottom-right = &button1;
-        sw-bottom-left = &button4;
         magn = &lis2mdl;
         accel = &bmi270;
         input = &cst816s;

--- a/app/drivers/sensor/CMakeLists.txt
+++ b/app/drivers/sensor/CMakeLists.txt
@@ -3,14 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# TODO:
-# Weird compilation issue when not using
-# zephyr_library()
-# zephyr_library_sources(apds9306.c)
-#
-# -> ..add_library cannot create target "..__app__drivers__sensor" because another
-# -> target with the same name already exists.  The existing target is a static...
-#
 add_subdirectory_ifdef(CONFIG_APDS9306 apds9306)
 add_subdirectory_ifdef(CONFIG_BME68X_EXT_IAQ bme68x_iaq)
 add_subdirectory_ifdef(CONFIG_BMP581 bmp581)

--- a/app/drivers/sensor/bmi270/private/bosch_bmi270_config.h
+++ b/app/drivers/sensor/bmi270/private/bosch_bmi270_config.h
@@ -68,66 +68,72 @@
 #define BOSCH_BMI270_REG_PWR_CTRL        0x7D
 #define BOSCH_BMI270_REG_CMD             0x7E
 
-/** @brief          
- *  @param p_dev    
- *  @param p_data   
+/** @brief
+ *  @param p_dev
+ *  @param p_data
  *  @return         0 when successful
 */
-int8_t bmi2_configure_enable_all(const struct device *p_dev, struct bmi270_data *p_data);
+int bmi2_configure_enable_all(const struct device *p_dev, struct bmi270_data *p_data);
 
-/** @brief          
- *  @param p_dev    
- *  @param p_range  
+/** @brief
+ *  @param p_dev
+ *  @param p_range
  *  @return         0 when successful
 */
 int bmi2_set_accel_range(const struct device *p_dev, const struct sensor_value *p_range);
 
-/** @brief          
- *  @param p_dev    
- *  @param p_odr    
+/** @brief
+ *  @param p_dev
+ *  @param p_odr
  *  @return         0 when successful
 */
 int bmi2_set_accel_odr(const struct device *p_dev, const struct sensor_value *p_odr);
 
-/** @brief          
- *  @param p_dev    
- *  @param p_osr    
+/** @brief
+ *  @param p_dev
+ *  @param p_osr
  *  @return         0 when successful
 */
 int bmi2_set_accel_osr(const struct device *p_dev, const struct sensor_value *p_osr);
 
-/** @brief          
- *  @param p_dev    
- *  @param p_range  
+/** @brief
+ *  @param p_dev
+ *  @param p_range
  *  @return         0 when successful
 */
 int bmi2_set_gyro_range(const struct device *p_dev, const struct sensor_value *p_range);
 
-/** @brief          
- *  @param p_dev    
- *  @param p_odr    
+/** @brief
+ *  @param p_dev
+ *  @param p_odr
  *  @return         0 when successful
 */
 int bmi2_set_gyro_odr(const struct device *p_dev, const struct sensor_value *p_odr);
 
-/** @brief          
- *  @param p_dev    
- *  @param p_osr     
+/** @brief
+ *  @param p_dev
+ *  @param p_osr
  *  @return         0 when successful
 */
 int bmi2_set_gyro_osr(const struct device *p_dev, const struct sensor_value *p_osr);
 
-/** @brief          
- *  @param p_dev    
- *  @param feature  
+/** @brief
+ *  @param p_dev
+ *  @param feature
  *  @return         0 when successful
 */
 int bmi2_disable_feature(const struct device *p_dev, uint8_t feature);
 
-/** @brief          
- *  @param p_dev    
- *  @param feature  
- *  @param int_en   
+/** @brief
+ *  @param p_dev
+ *  @param feature
+ *  @param int_en
  *  @return         0 when successful
 */
 int bmi2_enable_feature(const struct device *p_dev, uint8_t feature, bool int_en);
+
+/** @brief
+ *  @param p_dev
+ *  @return         0 when successful
+*/
+int bmi2_reset_step_counter(const struct device *p_dev);

--- a/app/src/applications/iaq/iaq_app.c
+++ b/app/src/applications/iaq/iaq_app.c
@@ -7,7 +7,6 @@
 #include "managers/zsw_app_manager.h"
 #include "sensors/zsw_environment_sensor.h"
 
-LV_IMG_DECLARE(move);
 LOG_MODULE_REGISTER(iaq_app, CONFIG_IAQ_APP_LOG_LEVEL);
 
 static void iaq_app_start(lv_obj_t *root, lv_group_t *group);
@@ -21,11 +20,11 @@ static application_t app = {
     .stop_func = iaq_app_stop
 };
 
-static void on_timer_event(lv_timer_t *timer)
+static void iaq_app_update(void)
 {
     float iaq;
 
-    if (zsw_environment_sensor_get_iaq(&iaq)) {
+    if (zsw_environment_sensor_get_iaq(&iaq) == 0) {
         LOG_DBG("Update UI...");
 
         iaq_app_ui_home_set_iaq_cursor(iaq);
@@ -34,13 +33,20 @@ static void on_timer_event(lv_timer_t *timer)
     }
 }
 
+static void on_timer_event(lv_timer_t *timer)
+{
+    iaq_app_update();
+}
+
 static void iaq_app_start(lv_obj_t *root, lv_group_t *group)
 {
     LOG_DBG("Starting UI...");
 
     iaq_app_ui_show(root);
 
-    refresh_timer = lv_timer_create(on_timer_event, 10 * 1000UL,  NULL);
+    iaq_app_update();
+
+    refresh_timer = lv_timer_create(on_timer_event, 1 * 1000UL,  NULL);
 }
 
 static void iaq_app_stop(void)

--- a/app/src/applications/iaq/ui_export/iaq_ui.h
+++ b/app/src/applications/iaq/ui_export/iaq_ui.h
@@ -2,12 +2,14 @@
 
 #include "lvgl.h"
 
-/** @brief          
+LV_IMG_DECLARE(move);
+
+/** @brief
  *  @param p_parent Pointer to UI parent
 */
 void iaq_app_ui_show(lv_obj_t *p_parent);
 
-/** @brief  
+/** @brief
 */
 void iaq_app_ui_remove(void);
 

--- a/app/src/applications/template/CMakeLists.txt
+++ b/app/src/applications/template/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(CONFIG_APPLICATIONS_USE_IAQ)
+if(CONFIG_APPLICATIONS_USE_TEMPLATE)
     FILE(GLOB app_sources *.c)
     target_sources(app PRIVATE ${app_sources})
     add_subdirectory(ui_export)

--- a/app/src/sensors/zsw_imu.h
+++ b/app/src/sensors/zsw_imu.h
@@ -98,6 +98,6 @@ int zsw_imu_fetch_num_steps(uint32_t *num_steps);
 
 int zsw_imu_reset_step_count(void);
 
-int zsw_imu_feature_enable(zsw_imu_feature_t feature, bool int_en);
-
 int zsw_imu_feature_disable(zsw_imu_feature_t feature);
+
+int zsw_imu_feature_enable(zsw_imu_feature_t feature, bool int_en);


### PR DESCRIPTION
BMI270:
- Add reset for step counter via offset attribute

IMU:
- Add a function to reset the step counter
- Add periodic reset at 00:00 for step counter (needs rework later when RTC is added)

Battery:
- Move "vbat" device tree entry into rev 1-4 files

IAQ app:
- Align app source name with other apps
- Add initial measurement during app startup

Template:
- Fix broken macro in CMakeLists

Misc:
- Remove "sw-top-right", "sw-top-left", "sw-bottom-right" and "sw-bottom-left" because they are unused