### PR TITLE
watchface: Add smooth second seconds hand and setting for interval.

### DIFF
--- a/app/src/applications/music_control/music_control_app.c
+++ b/app/src/applications/music_control/music_control_app.c
@@ -108,8 +108,9 @@ static void handle_update_ui(struct k_work *item)
 
 static void timer_callback(lv_timer_t *timer)
 {
-    struct tm *time = zsw_clock_get_time();
-    music_control_ui_set_time(time->tm_hour, time->tm_min, time->tm_sec);
+    zsw_timeval_t time;
+    zsw_clock_get_time(&time);
+    music_control_ui_set_time(time.tm.tm_hour, time.tm.tm_min, time.tm.tm_sec);
     if (playing) {
         progress_seconds++;
         music_control_ui_set_track_progress((((float)progress_seconds / (float)last_music_info.duration)) * 100);

--- a/app/src/applications/settings/settings_app.c
+++ b/app/src/applications/settings/settings_app.c
@@ -35,6 +35,7 @@ static void on_clear_storage_changed(lv_setting_value_t value, bool final);
 static void on_reboot_changed(lv_setting_value_t value, bool final);
 static void on_restart_screen_changed(lv_setting_value_t value, bool final);
 static void on_watchface_animation_changed(lv_setting_value_t value, bool final);
+static void on_watchface_tick_interval_changed(lv_setting_value_t value, bool final);
 
 static void ble_pairing_work_handler(struct k_work *work);
 static void display_restart_work_handler(struct k_work *work);
@@ -63,6 +64,7 @@ static setting_app_t settings_app = {
     .watchface = {
         .animations_on = false,
         .default_index = 0,
+        .smooth_second_hand = false
     },
 };
 
@@ -218,7 +220,18 @@ static lv_settings_item_t ui_page_items[] = {
                 .inital_val = &settings_app.watchface.animations_on,
             }
         }
-    }
+    },
+    {
+        .type = LV_SETTINGS_TYPE_SWITCH,
+        .icon = LV_SYMBOL_SETTINGS,
+        .change_callback = on_watchface_tick_interval_changed,
+        .item = {
+            .sw = {
+                .name = "Smooth watchface second hand",
+                .inital_val = &settings_app.watchface.smooth_second_hand,
+            }
+        }
+    },
 };
 
 static lv_settings_page_t settings_menu[] = {
@@ -374,6 +387,12 @@ static void on_restart_screen_changed(lv_setting_value_t value, bool final)
 static void on_watchface_animation_changed(lv_setting_value_t value, bool final)
 {
     settings_app.watchface.animations_on = value.item.sw;
+    settings_save_one(ZSW_SETTINGS_WATCHFACE, &settings_app.watchface, sizeof(settings_app.watchface));
+}
+
+static void on_watchface_tick_interval_changed(lv_setting_value_t value, bool final)
+{
+    settings_app.watchface.smooth_second_hand = value.item.sw;
     settings_save_one(ZSW_SETTINGS_WATCHFACE, &settings_app.watchface, sizeof(settings_app.watchface));
 }
 

--- a/app/src/applications/watchface/watchface_app.h
+++ b/app/src/applications/watchface/watchface_app.h
@@ -38,7 +38,7 @@ typedef struct watchface_ui_api_t {
     void (*set_battery_percent)(int32_t percent, int32_t value);
     void (*set_hrm)(int32_t value);
     void (*set_step)(int32_t value);
-    void (*set_time)(int32_t hour, int32_t minute, int32_t second);
+    void (*set_time)(int32_t hour, int32_t minute, int32_t second, uint32_t usec);
     void (*set_ble_connected)(bool connected);
     void (*set_num_notifcations)(int32_t value);
     void (*set_weather)(int8_t temperature, int weather_code);

--- a/app/src/sensors/zsw_imu.c
+++ b/app/src/sensors/zsw_imu.c
@@ -38,13 +38,12 @@ static struct sensor_trigger bmi270_trigger;
 
 static void zbus_periodic_slow_callback(const struct zbus_channel *chan)
 {
-    struct tm *timeinfo;
+    zsw_timeval_t time;
     struct accel_event evt = {
     };
+    zsw_clock_get_time(&time);
 
-    timeinfo = zsw_clock_get_time();
-
-    if ((timeinfo->tm_hour == 23) && (timeinfo->tm_min == 59)) {
+    if ((time.tm.tm_hour == 23) && (time.tm.tm_min == 59)) {
 
         LOG_DBG("Reset step counter");
         zsw_imu_reset_step_count();

--- a/app/src/ui/watchfaces/zsw_watchface_analog_ui.c
+++ b/app/src/ui/watchfaces/zsw_watchface_analog_ui.c
@@ -350,7 +350,7 @@ static void watchface_set_step(int32_t value)
     lv_obj_align_to(step_label, step_arc, LV_ALIGN_CENTER, 0, -9);
 }
 
-static void watchface_set_time(int32_t hour, int32_t minute, int32_t second)
+static void watchface_set_time(int32_t hour, int32_t minute, int32_t second, uint32_t usec)
 {
     if (!root_page) {
         return;

--- a/app/src/ui/watchfaces/zsw_watchface_digital_ui.c
+++ b/app/src/ui/watchfaces/zsw_watchface_digital_ui.c
@@ -544,14 +544,24 @@ static void watchface_set_step(int32_t value)
     lv_label_set_text_fmt(ui_step_arc_label, "%d", value);
 }
 
-static void watchface_set_time(int32_t hour, int32_t minute, int32_t second)
+static void watchface_set_time(int32_t hour, int32_t minute, int32_t second, uint32_t usec)
 {
     if (!root_page) {
         return;
     }
-    lv_label_set_text_fmt(ui_hour_label, "%02d", minute);
-    lv_label_set_text_fmt(ui_min_label, "%02d", hour);
-    lv_label_set_text_fmt(ui_sec_label, "%02d", second);
+
+    if (last_hour != hour) {
+        lv_label_set_text_fmt(ui_min_label, "%02d", hour);
+        last_hour = hour;
+    }
+    if (last_minute != minute) {
+        lv_label_set_text_fmt(ui_hour_label, "%02d", minute);
+        last_minute = minute;
+    }
+    if (last_second != second) {
+        lv_label_set_text_fmt(ui_sec_label, "%02d", second);
+        last_second = second;
+    }
 }
 
 static void watchface_set_num_notifcations(int32_t value)

--- a/app/src/ui/watchfaces/zsw_watchface_minimal_ui.c
+++ b/app/src/ui/watchfaces/zsw_watchface_minimal_ui.c
@@ -146,7 +146,7 @@ static void watchface_set_step(int32_t value)
 {
 }
 
-static void watchface_set_time(int32_t hour, int32_t minute, int32_t second)
+static void watchface_set_time(int32_t hour, int32_t minute, int32_t second, uint32_t usec)
 {
     int hour_minute_offset;
 
@@ -162,6 +162,8 @@ static void watchface_set_time(int32_t hour, int32_t minute, int32_t second)
     last_second = second * (3600 / 60);
     lv_img_set_angle(ui_hour_img, last_hour);
     lv_img_set_angle(ui_min_img, last_minute);
+
+    last_second += lv_map(usec, 0, 999999, 0, 3600 / 60);
     lv_img_set_angle(ui_second_img, last_second);
 }
 

--- a/app/src/zsw_clock.c
+++ b/app/src/zsw_clock.c
@@ -51,14 +51,14 @@ void zsw_clock_init(uint64_t start_time_seconds, char *timezone)
     zsw_periodic_chan_add_obs(&periodic_event_1s_chan, &zsw_clock_lis);
 }
 
-struct tm *zsw_clock_get_time(void)
+void zsw_clock_get_time(zsw_timeval_t *ztm)
 {
     struct timeval tv;
     struct tm *tm;
     gettimeofday(&tv, NULL);
     tm = localtime(&tv.tv_sec);
-
-    return tm;
+    memcpy(ztm, tm, sizeof(struct tm));
+    ztm->tv_usec = tv.tv_usec;
 }
 
 time_t zsw_clock_get_time_unix(void)

--- a/app/src/zsw_clock.h
+++ b/app/src/zsw_clock.h
@@ -20,6 +20,11 @@
 #include <inttypes.h>
 #include <time.h>
 
+typedef struct {
+    struct tm   tm;
+    uint32_t    tv_usec;
+} zsw_timeval_t;
+
 void zsw_clock_init(uint64_t start_time_seconds, char *timezone);
-struct tm *zsw_clock_get_time(void);
+void zsw_clock_get_time(zsw_timeval_t *ztm);
 time_t zsw_clock_get_time_unix(void);

--- a/app/src/zsw_settings.h
+++ b/app/src/zsw_settings.h
@@ -27,6 +27,7 @@ typedef int32_t zsw_settings_ble_aoa_int_t;
 typedef struct {
     bool animations_on;
     uint8_t default_index;
+    bool smooth_second_hand;
 } zsw_settings_watchface_t;
 #define ZSW_SETTINGS_KEY_WATCHFACE "watchface"
 #define ZSW_SETTINGS_WATCHFACE (ZSW_SETTINGS_PATH "/" ZSW_SETTINGS_KEY_WATCHFACE)


### PR DESCRIPTION
Setting to enable smooth as it will consume more CPU.
[Screencast from 2024-03-14 01:09:54.webm](https://github.com/jakkra/ZSWatch/assets/4318648/d6e300ba-f4b1-4318-aac9-3587aa2e72ac)
