### PR TITLE
Replace AoA guard

### DIFF
--- a/app/src/ble/ble_aoa.c
+++ b/app/src/ble/ble_aoa.c
@@ -15,7 +15,7 @@
  */
 #include <stdbool.h>
 #include <stdint.h>
-#ifdef CONFIG_BT_EXT_ADV
+#ifdef CONFIG_BT_DF
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/direction.h>


### PR DESCRIPTION
It seems like `CONFIG_BT_DF` would be more suitable here.

The reason for the change is while enabling the LE audio `CONFIG_BT_EXT_ADV` is set by the LE audio stuff and consequently break the build.