### PR TITLE
use astyle as default formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,8 @@
     "terminal.integrated.env.linux": {
         "GTK_PATH": ""
     },
-    "search.useIgnoreFiles": false
+    "search.useIgnoreFiles": false,
+    "[c]": {
+        "editor.defaultFormatter": "chiehyu.vscode-astyle"
+    }
 }


### PR DESCRIPTION
Cosmetic suggestion to use VSCode extension as the default formater.

At least on my setup, changing branches between projects would change formater and when saving the file with auto format would result in the whole file being formatted, messing with the OCD.