### PR TITLE
External (QSPI) flash read optimizations

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,6 +14,11 @@
             "command": "west upload_fs --type lfs"
         },
         {
+            "label": "Erase external flash",
+            "type": "shell",
+            "command": "west upload_fs --erase"
+        },
+        {
             "label": "Disable BT",
             "type": "shell",
             "command": "sudo btmgmt --index 0 power off"

--- a/app/scripts/upload_fs_west_command.py
+++ b/app/scripts/upload_fs_west_command.py
@@ -1,7 +1,7 @@
 from west.commands import WestCommand
 from west import log
 from create_custom_resource_image import create_custom_raw_fs_image
-from rtt_flash_loader import rtt_run_flush_loader
+from rtt_flash_loader import rtt_run_flush_loader, erase_external_flash
 from create_littlefs_resouce_image import create_littlefs_fs_image
 import sys
 import os
@@ -19,6 +19,12 @@ class UploadFsWestCommand(WestCommand):
     def do_add_parser(self, parser_adder):
         parser = parser_adder.add_parser(
             self.name, help=self.help, description=self.description
+        )
+
+        parser.add_argument(
+            "--erase",
+            action="store_true",
+            help="Erase the external (Q)SPI Flash",
         )
 
         parser.add_argument(
@@ -42,6 +48,11 @@ class UploadFsWestCommand(WestCommand):
         return parser
 
     def do_run(self, args, unknown_args):
+        if args.erase:
+            sys.exit(
+                erase_external_flash("nRF5340_XXAA")
+            )
+            return
         log.inf("Creating image")
         img_size = 2 * 1024 * 1024
         block_size = 4096

--- a/app/src/ui/utils/zsw_ui_utils.c
+++ b/app/src/ui/utils/zsw_ui_utils.c
@@ -20,14 +20,14 @@
 #include "managers/zsw_notification_manager.h"
 
 #if CONFIG_WATCHFACE_BACKGROUND_SPACE
-LV_IMG_DECLARE(space_blur_bg);
-const lv_img_dsc_t *global_watchface_bg_img = &space_blur_bg;
+ZSW_LV_IMG_DECLARE(space_blur_bg);
+const lv_img_dsc_t *global_watchface_bg_img = (const lv_img_dsc_t *)ZSW_LV_IMG_USE(space_blur_bg);
 #elif CONFIG_WATCHFACE_BACKGROUND_FLOWER
-LV_IMG_DECLARE(flower_watchface_bg);
-const lv_img_dsc_t *global_watchface_bg_img = &flower_watchface_bg;
+ZSW_LV_IMG_DECLARE(flower_watchface_bg);
+const lv_img_dsc_t *global_watchface_bg_img = (const lv_img_dsc_t *)ZSW_LV_IMG_USE(flower_watchface_bg);
 #elif CONFIG_WATCHFACE_BACKGROUND_PLANET
-LV_IMG_DECLARE(earth_blur_move);
-const lv_img_dsc_t *global_watchface_bg_img = &earth_blur_move;
+ZSW_LV_IMG_DECLARE(earth_blur_move);
+const lv_img_dsc_t *global_watchface_bg_img = (const lv_img_dsc_t *)ZSW_LV_IMG_USE(earth_blur_move);
 #else
 const lv_img_dsc_t *global_watchface_bg_img = NULL;
 #endif


### PR DESCRIPTION
- 2x FPS when scrolling watchfaces.
- Overall more responsive.
- Few more FPS here and there where QSPI Flash access was the bottleneck.

Thanks to those imporvements there is now no performance issues putting default watchface background images in external flash freeing up 115KB internal flash :partying_face: 

Imporvements:
1. Make all reads from external flash aligned as the QSPI driver will split uniligned reads into 2-3 seperate reads (depending on if both start and end address is unaligned). Now instead make sure all reads are aligned by reading into a temporary buffer.
2. Added caching when reading from external flash. Only one image at a time, but this is fine as LVGL will often read most of one image in a row by row after each other.