### PR TITLE
App Manager: Send back button presses to applications and let them co…

### DIFF
--- a/app/src/applications/settings/settings_app.c
+++ b/app/src/applications/settings/settings_app.c
@@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(settings_app, CONFIG_ZSW_SETTINGS_APP_LOG_LEVEL);
 
 static void settings_app_start(lv_obj_t *root, lv_group_t *group);
 static void settings_app_stop(void);
+static bool settings_app_back(void);
 
 static void on_close_settings(void);
 static void on_brightness_changed(lv_setting_value_t value, bool final);
@@ -74,7 +75,8 @@ static application_t app = {
     .name = "Settings",
     .icon = ZSW_LV_IMG_USE(settings),
     .start_func = settings_app_start,
-    .stop_func = settings_app_stop
+    .stop_func = settings_app_stop,
+    .back_func = settings_app_back,
 };
 
 static lv_settings_item_t display_page_items[] = {
@@ -285,6 +287,11 @@ static void settings_app_start(lv_obj_t *root, lv_group_t *group)
 static void settings_app_stop(void)
 {
     settings_ui_remove();
+}
+
+static bool settings_app_back(void)
+{
+    return settings_ui_back();
 }
 
 static void on_close_settings(void)

--- a/app/src/applications/settings/settings_ui.c
+++ b/app/src/applications/settings/settings_ui.c
@@ -244,3 +244,13 @@ void settings_ui_remove(void)
         _menu = NULL;
     }
 }
+
+bool settings_ui_back(void)
+{
+    if ((_menu != NULL) && ((lv_menu_t *)_menu)->cur_depth > 1) {
+        lv_event_send(lv_menu_get_main_header_back_btn(_menu), LV_EVENT_CLICKED, NULL);
+        return true;
+    } else {
+        return false;
+    }
+}

--- a/app/src/applications/settings/settings_ui.h
+++ b/app/src/applications/settings/settings_ui.h
@@ -86,3 +86,5 @@ void lv_settings_create(lv_obj_t *root, lv_settings_page_t *pages, uint8_t num_p
                         on_close_cb_t close_cb);
 
 void settings_ui_remove(void);
+
+bool settings_ui_back(void);

--- a/app/src/managers/zsw_app_manager.c
+++ b/app/src/managers/zsw_app_manager.c
@@ -118,23 +118,20 @@ static void async_app_close(lv_timer_t *timer)
 {
     if (current_app < num_apps) {
         LOG_DBG("Stop %d", current_app);
-        bool app_start_pending = async_app_start_timer != NULL;
-        // If an app is already scheduled to start,
-        // then stop it and skip calling the apps stop_func.
-        if (app_start_pending) {
-            lv_timer_del(async_app_start_timer);
-            async_app_start_timer = NULL;
-        } else {
-            apps[current_app]->stop_func();
+        bool back_button_consumed = false;
+        if (apps[current_app]->back_func) {
+            back_button_consumed = apps[current_app]->back_func();
         }
-        current_app = INVALID_APP_ID;
-        if (app_launch_only) {
-            zsw_app_manager_delete();
-            close_cb_func();
-        } else if (!app_start_pending) {
-            // Check if an app was pending to start, then the application_picker was
-            // not yet deleted, hence we don't redraw it.
-            draw_application_picker();
+
+        if (!back_button_consumed) {
+            apps[current_app]->stop_func();
+            current_app = INVALID_APP_ID;
+            if (app_launch_only) {
+                zsw_app_manager_delete();
+                close_cb_func();
+            } else {
+                draw_application_picker();
+            }
         }
     } else {
         // No app running, then close whole application_manager

--- a/app/src/managers/zsw_app_manager.h
+++ b/app/src/managers/zsw_app_manager.h
@@ -21,12 +21,17 @@
 
 typedef void(*application_start_fn)(lv_obj_t *root, lv_group_t *group);
 typedef void(*application_stop_fn)(void);
+/*
+* Return true if the back button was consumed by the application.
+*/
+typedef bool(*application_back_fn)(void);
 
 typedef void(*on_app_manager_cb_fn)(void);
 
 typedef struct application_t {
     application_start_fn    start_func;
     application_stop_fn     stop_func;
+    application_back_fn     back_func;
     char                   *name;
     const void             *icon;
     bool                    hidden;


### PR DESCRIPTION
…nsume it instead of always exiting the app.

In settings app finally back button won't exit the app if pressed when inside a sub menu. Instead it will go back one menu level.

Originally implemented in https://github.com/Kampi/ZSWatch/tree/Rework-Sensors-Summary, but extracted from that branch and I also implemented the logic for Settings App to utilize it.